### PR TITLE
Shrink size of Extensibility.Standalone image

### DIFF
--- a/src/Extensibility.Standalone/CrudHelper.cs
+++ b/src/Extensibility.Standalone/CrudHelper.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Extensibility.Core.Contract;
+using Extensibility.Core.Data;
+
 namespace Extensibility.Standalone
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Extensibility.Core.Contract;
-    using Extensibility.Core.Data;
-
     public static class CrudHelper
     {
         private static IExtensibilityProvider GetResourceOperations(ExtensibleResourceBody resource)

--- a/src/Extensibility.Standalone/Dockerfile
+++ b/src/Extensibility.Standalone/Dockerfile
@@ -1,26 +1,35 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal AS base
+# See https://hub.docker.com/_/microsoft-dotnet-runtime-deps/
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine AS base
 WORKDIR /app
 EXPOSE 5000
 
 ENV ASPNETCORE_URLS=http://+:5000
+
+# Enabling globalization
+ENV \
+     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+     LC_ALL=en_US.UTF-8 \
+     LANG=en_US.UTF-8
+RUN apk add --no-cache icu-libs
 
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
 # For more info, please refer to https://aka.ms/vscode-docker-dotnet-configure-containers
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
+COPY ["src/Extensibility.Core/Extensibility.Core.csproj", "src/Extensibility.Core/"]
+COPY ["src/Extensibility.AzureStorage/Extensibility.AzureStorage.csproj", "src/Extensibility.AzureStorage/"]
+COPY ["src/Extensibility.Kubernetes/Extensibility.Kubernetes.csproj", "src/Extensibility.Kubernetes/"]
 COPY ["src/Extensibility.Standalone/Extensibility.Standalone.csproj", "src/Extensibility.Standalone/"]
-RUN dotnet restore "src/Extensibility.Standalone/Extensibility.Standalone.csproj"
+RUN dotnet restore "src/Extensibility.Standalone/Extensibility.Standalone.csproj" -r linux-musl-x64 /p:PublishReadyToRun=false
 COPY . .
 WORKDIR "/src/src/Extensibility.Standalone"
-RUN dotnet build "Extensibility.Standalone.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Extensibility.Standalone.csproj" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "Extensibility.Standalone.csproj" -c Release -o /app/publish -r linux-musl-x64 --self-contained true --no-restore /p:PublishReadyToRun=false /p:PublishSingleFile=true
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "Extensibility.Standalone.dll"]
+COPY --from=build /app/publish .
+ENTRYPOINT ["/app/Extensibility.Standalone"]
+

--- a/src/Extensibility.Standalone/Program.cs
+++ b/src/Extensibility.Standalone/Program.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 namespace Extensibility.Standalone
 {
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-
     class Program
     {
         static async Task Main(string[] args)

--- a/src/Extensibility.Standalone/Providers.cs
+++ b/src/Extensibility.Standalone/Providers.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using Extensibility.AzureStorage;
+using Extensibility.Kubernetes;
+using Extensibility.Core.Contract;
+
 namespace Extensibility.Standalone
 {
-    using System.Collections.Generic;
-    using Extensibility.AzureStorage;
-    using Extensibility.Kubernetes;
-    using Extensibility.Core.Contract;
-    using System;
-
     public static class Providers
     {
         private static readonly IReadOnlyDictionary<string, IExtensibilityProvider> ProvidersLookup = new Dictionary<string, IExtensibilityProvider>

--- a/src/Extensibility.Standalone/packages.lock.json
+++ b/src/Extensibility.Standalone/packages.lock.json
@@ -13,6 +13,28 @@
           "Newtonsoft.Json.Bson": "1.0.2"
         }
       },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.3, )",
+        "resolved": "3.3.3",
+        "contentHash": "vvz3XCHVrd/Ks4xPoutLmL/T2+8JcOk/OMs3ngwQqnzokQCGEDsY+WjK/txCsDWU29sX3fGzH/FnYwNV93O1mA=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.5.107, )",
+        "resolved": "3.5.107",
+        "contentHash": "oMWWTe9aTUJ1CwU4fpfpduqx7Hzve320PU2SUyFFDzlHXTdjEouWHtFrRbaXV4LysL0lBtlzJM/nmHm47p2KWw=="
+      },
       "Swashbuckle.AspNetCore": {
         "type": "Direct",
         "requested": "[6.2.3, )",
@@ -128,6 +150,11 @@
         "resolved": "1.1.1",
         "contentHash": "MalY0Y/uM/LjXtHfX/26l2VtN4LDNZ2OE3aumNOHDLsT4fNYy2hiHXI4CXCqKpNUNm7iJ2brrc4J89UdaL56FA=="
       },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
       "Microsoft.CSharp": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -236,6 +263,11 @@
         "dependencies": {
           "Newtonsoft.Json": "10.0.3"
         }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",


### PR DESCRIPTION
This change switches the extensibility.standalone image to use alpine
and self-contained publishing.

This has the overall effect of reducing size from 250mb -> 112mb.

I did not turn on assembly trimming because there are many many warnings
showing up from libraries.