### PR TITLE
Fix web app stack

### DIFF
--- a/deploy/dev-host.bicep
+++ b/deploy/dev-host.bicep
@@ -19,7 +19,7 @@ resource webApp 'Microsoft.Web/sites@2021-03-01' = {
   properties: {
     serverFarmId: webAppPlan.id
     siteConfig: {
-      linuxFxVersion: 'DOTNET|6.0'
+      linuxFxVersion: 'DOTNETCORE|6.0'
     }
   }
 }


### PR DESCRIPTION
`siteConfig.linuxFxVersion` accepts `DOTNETCORE|6.0`, while it's set to `DOTNET|6.0`.