### PR TITLE
Specifying net6.0 as target framework for projects

### DIFF
--- a/src/Azure.Deployments.Extensibility.Core.Tests.Unit/Azure.Deployments.Extensibility.Core.Tests.Unit.csproj
+++ b/src/Azure.Deployments.Extensibility.Core.Tests.Unit/Azure.Deployments.Extensibility.Core.Tests.Unit.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />

--- a/src/Azure.Deployments.Extensibility.Core/Azure.Deployments.Extensibility.Core.csproj
+++ b/src/Azure.Deployments.Extensibility.Core/Azure.Deployments.Extensibility.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableNuget>true</EnableNuget>
   </PropertyGroup>
 

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Core/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Core.csproj
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Core/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Core.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
   </ItemGroup>

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration.csproj
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.csproj
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes/Azure.Deployments.Extensibility.Providers.Kubernetes.csproj
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes/Azure.Deployments.Extensibility.Providers.Kubernetes.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableNuget>true</EnableNuget>
   </PropertyGroup>
 


### PR DESCRIPTION
I'm surprised things were compiling without specifying this in general...