### PR TITLE
Include OCI tag in container name

### DIFF
--- a/src/Azure.Deployments.Extensibility.DevHost/Controllers/ExtensibilityOperationController.cs
+++ b/src/Azure.Deployments.Extensibility.DevHost/Controllers/ExtensibilityOperationController.cs
@@ -95,7 +95,7 @@ namespace Azure.Deployments.Extensibility.DevHost.Controllers
         {
             var providerName = request.Import.Provider;
             var tag = request.Import.Version;
-            var containerGroupName = $"{providerName}-aci";
+            var containerGroupName = GenerateContainerGroupName(providerName, tag);
 
             var providerContainerRegistry = registry.TryGetExtensibilityProviderContainerRegistry(providerName);
 
@@ -167,5 +167,12 @@ namespace Azure.Deployments.Extensibility.DevHost.Controllers
                     resourceGroupName: ContainerInstanceResourceGroupName,
                     containerGroupName: containerGroupName,
                     cancellation: cancellation);
+	
+        private static string GenerateContainerGroupName(string providerName, string providerVersion)
+        {
+            var desiredName = $"{providerName}-{providerVersion}".ToLowerInvariant();
+
+            return new string(desiredName.Select(x => char.IsLetterOrDigit(x) ? x : '-').ToArray());
+        }
     }
 }


### PR DESCRIPTION
In the scenario where we want to run a v1 & v2 provider side-by-side, we should ensure the two containers won't conflict with each other.