### PR TITLE
Check for repo existence dynamically

### DIFF
--- a/src/Azure.Deployments.Extensibility.DevHost/packages.lock.json
+++ b/src/Azure.Deployments.Extensibility.DevHost/packages.lock.json
@@ -75,10 +75,10 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.4",
-        "contentHash": "GhTCm4Hh2Hs+MUQL5ocIn+dqcfPzyTkCjkIji/IuATZ/Nyr1FZHCaHm44P3Mj0uuXbBLgXejFlypDlTyKMJcsw==",
+        "resolved": "1.0.0",
+        "contentHash": "AsnLpJqXUtVKEYFp3SJeRY9S+O4jfJtCb8o6BwkTHuY7i/U9uKdAaVCXMcXqtXuTUJCOk20lZ3oK8FWNMiiqkg==",
         "dependencies": {
-          "Azure.Core": "1.24.0",
+          "Azure.Core": "1.22.0",
           "System.Text.Json": "4.7.2"
         }
       },
@@ -2075,7 +2075,7 @@
       "azure.deployments.extensibility.providers.thirdparty": {
         "type": "Project",
         "dependencies": {
-          "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
+          "Azure.Containers.ContainerRegistry": "[1.0.0, )",
           "Azure.Deployments.Extensibility.Core": "[1.0.0, )",
           "Azure.Identity": "[1.7.0, )",
           "Microsoft.Azure.Management.ContainerInstance": "[7.0.0, )",

--- a/src/Azure.Deployments.Extensibility.Providers.ThirdParty/Azure.Deployments.Extensibility.Providers.ThirdParty.csproj
+++ b/src/Azure.Deployments.Extensibility.Providers.ThirdParty/Azure.Deployments.Extensibility.Providers.ThirdParty.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
-    <PackageReference Include="Azure.Containers.ContainerRegistry" Version="1.1.0-beta.4" />
+    <PackageReference Include="Azure.Containers.ContainerRegistry" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerInstance.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />

--- a/src/Azure.Deployments.Extensibility.Providers.ThirdParty/packages.lock.json
+++ b/src/Azure.Deployments.Extensibility.Providers.ThirdParty/packages.lock.json
@@ -4,11 +4,11 @@
     "net6.0": {
       "Azure.Containers.ContainerRegistry": {
         "type": "Direct",
-        "requested": "[1.1.0-beta.4, )",
-        "resolved": "1.1.0-beta.4",
-        "contentHash": "GhTCm4Hh2Hs+MUQL5ocIn+dqcfPzyTkCjkIji/IuATZ/Nyr1FZHCaHm44P3Mj0uuXbBLgXejFlypDlTyKMJcsw==",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "AsnLpJqXUtVKEYFp3SJeRY9S+O4jfJtCb8o6BwkTHuY7i/U9uKdAaVCXMcXqtXuTUJCOk20lZ3oK8FWNMiiqkg==",
         "dependencies": {
-          "Azure.Core": "1.24.0",
+          "Azure.Core": "1.22.0",
           "System.Text.Json": "4.7.2"
         }
       },


### PR DESCRIPTION
This removes the need to hardcode a list of supported providers, and instead allows us to be powered by whatever has been published to the container registry.