### PR TITLE
Exclude 3rd party provider from packing in official build

### DIFF
--- a/src/Azure.Deployments.Extensibility.Providers.ThirdParty/Azure.Deployments.Extensibility.Providers.ThirdParty.csproj
+++ b/src/Azure.Deployments.Extensibility.Providers.ThirdParty/Azure.Deployments.Extensibility.Providers.ThirdParty.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <EnableNuget>true</EnableNuget>
+    <EnableNuget>false</EnableNuget>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The 3rd party provider project has a reference to `Azure.ResourceManager.Applications.Containers [1.0.0-beta.1, )` which is causing the following failure in the `dotnet pack` step in official build:
```
error NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec
of dependency "Azure.ResourceManager.Applications.Containers [1.0.0-beta.1, )" or update the version field in
the nuspec.
```

The PR makes the 3rd party provider project non-packable to fix the error.