### PR TITLE
Set up dependency injection for Kubernetes v2 extension

### DIFF
--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integration/Properties/AssemblyInfo.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integration/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+[assembly: AssemblyTrait("Category", "Integration")]

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Properties/AssemblyInfo.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+[assembly: AssemblyTrait("Category", "Unit")]

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/DependencyInjection/IServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore;
+using Azure.Deployments.Extensibility.Core.V2.Models;
+using Azure.Deployments.Extensibility.Core.V2.Validation;
+using Azure.Deployments.Extensibility.Extensions.Kubernetes.Client;
+using Azure.Deployments.Extensibility.Extensions.Kubernetes.Validation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.DependencyInjection
+{
+    public static class IServiceCollectionExtensions
+    {
+        public static IServiceCollection AddKubernetesExtensionDispatcher(this IServiceCollection services) => services
+            .AddSingleton<IModelValidator<ResourceSpecification>, ResourceSpecificationValidator>()
+            .AddSingleton<IModelValidator<ResourceReference>, ResourceReferenceValidator>()
+            .AddSingleton<IK8sClientFactory, K8sClientFactory>()
+            .AddKeyedSingleton<IExtensionDispatcher, KubernetesExtensionDispatcher>(KubernetesExtension.ExtensionName);
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/KubernetesExtension.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/KubernetesExtension.cs
@@ -14,6 +14,8 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes
 {
     internal class KubernetesExtension : IExtension
     {
+        public const string ExtensionName = "Kubernetes";
+
         private readonly IModelValidator<ResourceSpecification> resourceSpecificationValidator;
         private readonly IModelValidator<ResourceReference> resourceReferenceValidator;
         private readonly IK8sClientFactory k8sClientFactory;

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration/KubernetesProviderTests.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration/KubernetesProviderTests.cs
@@ -19,9 +19,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
     // and after running all test cases.
     public class KubernetesProviderTests
     {
-        private const string SkipReason = "V1 Implementation is being deprecated";
-
-        [Theory(Skip = SkipReason), AzureVoteBackDeploymentRequestAutoData]
+        [Theory, AzureVoteBackDeploymentRequestAutoData]
         public async Task SaveAsync_AzureVoteBackDeployment_Succeeds(ExtensibilityOperationRequest request, KubernetesProvider sut)
         {
             var response = await sut.SaveAsync(request, CancellationToken.None);
@@ -29,7 +27,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
             response.Should().BeOfType<ExtensibilityOperationSuccessResponse>();
         }
 
-        [Theory(Skip = SkipReason), AzureVoteBackServiceRequestAutoData]
+        [Theory, AzureVoteBackServiceRequestAutoData]
         public async Task SaveAsync_AzureVoteBackService_Succeeds(ExtensibilityOperationRequest request, KubernetesProvider sut)
         {
             var response = await sut.SaveAsync(request, CancellationToken.None);
@@ -37,7 +35,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
             response.Should().BeOfType<ExtensibilityOperationSuccessResponse>();
         }
 
-        [Theory(Skip = SkipReason), RandomNamespaceRequestAutoData]
+        [Theory, RandomNamespaceRequestAutoData]
         public async Task GetAsync_SavedNamespace_Succeeds(ExtensibilityOperationRequest request, KubernetesProvider sut)
         {
             await sut.SaveAsync(request, CancellationToken.None);
@@ -49,7 +47,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
             successResponse.Resource.Properties.GetProperty("metadata").TryGetProperty("uid", out _).Should().BeTrue();
         }
 
-        [Theory(Skip = SkipReason), RandomNamespaceRequestAutoData]
+        [Theory, RandomNamespaceRequestAutoData]
         public async Task PreviewSaveAsync_WithExistingNamespace_PerformsServerSideDryRun(ExtensibilityOperationRequest namespaceRequest, KubernetesProvider sut)
         {
             await sut.SaveAsync(namespaceRequest, CancellationToken.None);
@@ -75,7 +73,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
             labelTwo.GetString().Should().Be("valueTwo");
         }
 
-        [Theory(Skip = SkipReason), AutoData]
+        [Theory, AutoData]
         public async Task PreviewSaveAsync_WithoutExistingNamespace_PerformsClientSideDryRun(Fixture fixture, KubernetesProvider sut)
         {
             var nonexistentNamespace = fixture.Create<string>();


### PR DESCRIPTION
Used the keyed service dependency added in .NET 8. This enables the extensibility host to select `IExtensionDispatcher` based on the extension name:

```C#
var extensionDispatcher = serviceProvider.GetKeyedService<IExtensionDispatcher>(extensionName);
```