### PR TITLE
Implement Config ID field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,7 @@ deploy/package/
 deploy/package.zip
 deploy/dev-host
 deploy/dev-host.zip
+
+# JetBrains
+.idea/
+*.iml

--- a/docs/vnext/openapi.yaml
+++ b/docs/vnext/openapi.yaml
@@ -29,8 +29,10 @@ paths:
       description: |
         Preview a resource creation or update operation by simulating the process.
 
-        Upon successful simulation, the outcome must mirror a resource that has been either created or updated, based on the operation that was previewed. This resulting state should align with what would be ontained from a GET response, as if the genuine create or update operation had been carried out. This includes the inclusion of read-only properties and properties endowed with default values, as well as the exclusion of write-only properties like those containing sensitive information such as passwords and connection strings.
-
+        Upon successful simulation, the outcome must mirror a resource that has been either created or updated, based on the operation that was previewed. This resulting state should align with what would be obtained from a GET response, as if the genuine create or update operation had been carried out. This includes the inclusion of read-only properties and properties endowed with default values, as well as the exclusion of write-only properties like those containing sensitive information such as passwords and connection strings.
+        Additionally, the service must provide a configuration ID if a user configuration is received. This property should uniquely identify a deployment control plane and its format is decided by the extension. It is used as a checksum for some resource operations such as deletion.
+        A configuration ID is not required as input, however, if one is provided, it will be validated.
+        
         Should the simulation encounter failure due to invalid properties, the response must detail the errors encountered.
         
         [TODO 1]: We need to explore strategies for handling ARM template expressions.
@@ -69,10 +71,12 @@ paths:
         Create or update a resource.
         
         Upon successful operation, the service must add an identifiers property to its response. This property is an object consisting of several sub-properties that, when combined with the resource's type and configuration, create a *globally unique* key for identifying the resource. The structure of the identifiers property is determined by the extension service and is opaque to the template deployment engine.
-
+        Additionally, the service must provide a configuration ID if a user configuration is received. This property should uniquely identify a deployment control plane and its format is decided by the extension. It is used as a checksum for some resource operations such as deletion.
+        A configuration ID is not required as input, however, if one is provided, it will be validated.
+        
         If the operation is synchronous or a resource based long-running operation (RELO), the response status code should be 201 Created for nonexistent resource or 200 OK for existing resource. However, if the extension service cannot determine whether the resource already exists, or if determining this is costly (e.g., requiring an additional query), it is acceptable to return a 200 OK status code.
 
-        If the opeartion is being implemented as a stepwise long-running operation (LRO), the response status code should be 202 Accepted.
+        If the operation is being implemented as a stepwise long-running operation (LRO), the response status code should be 202 Accepted.
       operationId: createOrUpdateResource
       parameters:
         - $ref: '#/components/parameters/HeaderAcceptLanguage'
@@ -108,6 +112,9 @@ paths:
       summary: Get a resource
       description: |
         Get a resource given its type, identifiers, and configuration.
+        
+        Additionally, the service must provide a configuration ID if a user configuration is received. This property should uniquely identify a deployment control plane and its format is decided by the extension. It is used as a checksum for some resource operations such as deletion.
+        A configuration ID is not required as input, however, if one is provided, it will be validated.
       operationId: getResource
       parameters:
         - $ref: '#/components/parameters/HeaderAcceptLanguage'
@@ -137,7 +144,7 @@ paths:
        - Resource
       summary: Delete a resource
       description: |
-        Delete a resource given its type, identifiers, and configuration.
+        Delete a resource given its type, identifiers, configuration, and configuration ID. A configuration ID is required for checksum validation if a configuration is present.
       operationId: deleteResource
       parameters:
         - $ref: '#/components/parameters/HeaderAcceptLanguage'
@@ -397,6 +404,8 @@ components:
           type: object
         config:
           $ref: '#/components/schemas/Config'
+        configId:
+          $ref: '#/components/schemas/ConfigId'
         type:
           type: string
           description: The type of the resource.
@@ -418,6 +427,9 @@ components:
       type: object
       writeOnly: true
       description: Contains configuration items that are served as necessary context information for completing the resource operation. This is the user-supplied extension configuration in the Bicep or ARM template file.
+    ConfigId:
+      type: string
+      description: An ID for the provided extension configuration that is calculated by the extension. This is used to uniquely identify a deployment control plane and is used as a checksum for some operations on a resource such as deletion. The extension decides the format of the ID. The extension is required to provide this if a configuration is supplied. The user must provide this configuration ID back to the extension for operations that require configuration checksum validation.
     Resource:
       type: object
       required:
@@ -426,6 +438,8 @@ components:
       properties:
         config:
           $ref: '#/components/schemas/Config'
+        configId:
+          $ref: '#/components/schemas/ConfigId'
         identifiers:
           type: object
           description: An object comprising key properties that, when paired with the resource's type and configuration, uniquely identify a resource. These properties are generally a subset of the resource properties provided in the createOrUpdate request payload. Occasionally, the extension might want incorporate extra properties to enhance validation. For instance, in the context of a Kubernetes extension, the inclusion of a clusterHostHash identifier might be imperative. This necessity arises in situations where the configuration of a Kubernetes resource gets changed subsequent to its initial creation.

--- a/docs/vnext/openapi.yaml
+++ b/docs/vnext/openapi.yaml
@@ -400,7 +400,7 @@ components:
         - type
       properties:
         identifiers:
-          description: An object comprising key properties that, when paired with the resource's type and configuration, uniquely identify a resource. These properties are generally a subset of the resource properties provided in the createOrUpdate request payload. Occasionally, the extension might want incorporate extra properties to enhance validation. For instance, in the context of a Kubernetes extension, the inclusion of a clusterHostHash identifier might be imperative. This necessity arises in situations where the configuration of a Kubernetes resource gets changed subsequent to its initial creation.
+          description: An object comprising key properties that, when paired with the resource's type and configuration, uniquely identify a resource. These properties are generally a subset of the resource properties provided in the createOrUpdate request payload.
           type: object
         config:
           $ref: '#/components/schemas/Config'
@@ -429,7 +429,7 @@ components:
       description: Contains configuration items that are served as necessary context information for completing the resource operation. This is the user-supplied extension configuration in the Bicep or ARM template file.
     ConfigId:
       type: string
-      description: An ID for the provided extension configuration that is calculated by the extension. This is used to uniquely identify a deployment control plane and is used as a checksum for some operations on a resource such as deletion. The extension decides the format of the ID. The extension is required to provide this if a configuration is supplied. The user must provide this configuration ID back to the extension for operations that require configuration checksum validation.
+      description: An ID for the provided extension configuration that is calculated by the extension. This is used to uniquely identify a deployment control plane and is used as a checksum for some operations on a resource such as deletion. The extension decides the format of the ID. The ID is treated case-sensitively by the deployment engine so the extension should normalize casing. The extension is required to provide this if a configuration is supplied. The user must provide this configuration ID back to the extension for operations that require configuration checksum validation.
     Resource:
       type: object
       required:
@@ -442,7 +442,7 @@ components:
           $ref: '#/components/schemas/ConfigId'
         identifiers:
           type: object
-          description: An object comprising key properties that, when paired with the resource's type and configuration, uniquely identify a resource. These properties are generally a subset of the resource properties provided in the createOrUpdate request payload. Occasionally, the extension might want incorporate extra properties to enhance validation. For instance, in the context of a Kubernetes extension, the inclusion of a clusterHostHash identifier might be imperative. This necessity arises in situations where the configuration of a Kubernetes resource gets changed subsequent to its initial creation.
+          description: An object comprising key properties that, when paired with the resource's type and configuration, uniquely identify a resource. These properties are generally a subset of the resource properties provided in the createOrUpdate request payload.
           readOnly: true
         status:
           $ref: '#/components/schemas/Status'

--- a/src/Azure.Deployments.Extensibility.Core/V2/Models/Resource.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Models/Resource.cs
@@ -14,7 +14,7 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         }
 
         [SetsRequiredMembers]
-        public Resource(string type, string? apiVersion, JsonObject identifiers, JsonObject properties, string configId, string? status = null)
+        public Resource(string type, string? apiVersion, JsonObject identifiers, JsonObject properties, string? configId = null, string? status = null)
             : base(type, apiVersion, identifiers, properties, configId, status)
         {
         }
@@ -27,7 +27,7 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         }
 
         [SetsRequiredMembers]
-        public Resource(string type, string? apiVersion, TIdentifiers identifiers, TProperties properties, string configId, string? status = null)
+        public Resource(string type, string? apiVersion, TIdentifiers identifiers, TProperties properties, string? configId = null, string? status = null)
         {
             this.Type = type;
             this.ApiVersion = apiVersion;
@@ -46,7 +46,7 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         public required TProperties Properties { get; init; }
 
         public string? Status { get; init; } = null;
-        
-        public required string ConfigId { get; init; }
+
+        public string? ConfigId { get; init; }
     }
 }

--- a/src/Azure.Deployments.Extensibility.Core/V2/Models/Resource.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Models/Resource.cs
@@ -14,8 +14,8 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         }
 
         [SetsRequiredMembers]
-        public Resource(string type, string? apiVersion, JsonObject identifiers, JsonObject properties, string? status = null)
-            : base(type, apiVersion, identifiers, properties, status)
+        public Resource(string type, string? apiVersion, JsonObject identifiers, JsonObject properties, string configId, string? status = null)
+            : base(type, apiVersion, identifiers, properties, configId, status)
         {
         }
     }
@@ -27,12 +27,13 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         }
 
         [SetsRequiredMembers]
-        public Resource(string type, string? apiVersion, TIdentifiers identifiers, TProperties properties, string? status = null)
+        public Resource(string type, string? apiVersion, TIdentifiers identifiers, TProperties properties, string configId, string? status = null)
         {
             this.Type = type;
             this.ApiVersion = apiVersion;
             this.Identifiers = identifiers;
             this.Properties = properties;
+            this.ConfigId = configId;
             this.Status = status;
         }
 
@@ -45,5 +46,7 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         public required TProperties Properties { get; init; }
 
         public string? Status { get; init; } = null;
+        
+        public required string ConfigId { get; init; }
     }
 }

--- a/src/Azure.Deployments.Extensibility.Core/V2/Models/ResourceReference.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Models/ResourceReference.cs
@@ -42,5 +42,7 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         public required TIdentifiers Identifiers { get; init; }
 
         public TConfig? Config { get; init; }
+        
+        public string? ConfigId { get; init; }
     }
 }

--- a/src/Azure.Deployments.Extensibility.Core/V2/Models/ResourceSpecification.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Models/ResourceSpecification.cs
@@ -14,8 +14,8 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         }
 
         [SetsRequiredMembers]
-        public ResourceSpecification(string type, string? apiVersion, JsonObject properties, JsonObject? config)
-            : base(type, apiVersion, properties, config)
+        public ResourceSpecification(string type, string? apiVersion, JsonObject properties, JsonObject? config, string? configId = null)
+            : base(type, apiVersion, properties, config, configId)
         {
         }
     }
@@ -27,12 +27,13 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         }
 
         [SetsRequiredMembers]
-        public ResourceSpecification(string type, string? apiVersion, TProperties properties, TConfig? config)
+        public ResourceSpecification(string type, string? apiVersion, TProperties properties, TConfig? config, string? configId = null)
         {
             this.Type = type;
             this.ApiVersion = apiVersion;
             this.Properties = properties;
             this.Config = config;
+            this.ConfigId = configId;
         }
 
         public required string Type { get; init; }
@@ -42,5 +43,7 @@ namespace Azure.Deployments.Extensibility.Core.V2.Models
         public required TProperties Properties { get; init; }
 
         public TConfig? Config { get; init; }
+
+        public string? ConfigId { get; init; }
     }
 }

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Api/K8sClusterScopedApiTests.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Api/K8sClusterScopedApiTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Nodes;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using AutoFixture.Xunit2;
@@ -8,7 +9,6 @@ using Azure.Deployments.Extensibility.AspNetCore.Exceptions;
 using Azure.Deployments.Extensibility.Extensions.Kubernetes.Api;
 using Azure.Deployments.Extensibility.Extensions.Kubernetes.Models;
 using FluentAssertions;
-using System.Text.Json.Nodes;
 using static FluentAssertions.FluentActions;
 
 namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Api
@@ -24,9 +24,9 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Api
         }
 
         [Theory, NamespacedK8sObjectAutoData]
-        internal async Task GetObjectAsync_NamespacedObject_Throws(K8sObject namespacedObject, string serverHost, K8sClusterScopedApi sut)
+        internal async Task GetObjectAsync_NamespacedObject_Throws(K8sObject namespacedObject, K8sClusterScopedApi sut)
         {
-            var namespacedIdentifiers = K8sObjectIdentifiers.Create(namespacedObject, serverHost);
+            var namespacedIdentifiers = K8sObjectIdentifiers.Create(namespacedObject);
 
             await Invoking(() => sut.GetObjectAsync(namespacedIdentifiers, default))
                 .Should()
@@ -34,9 +34,9 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Api
         }
 
         [Theory, NamespacedK8sObjectAutoData]
-        internal async Task DeleteObjectAsync_NamespacedObject_Throws(K8sObject namespacedObject, string serverHost, K8sClusterScopedApi sut)
+        internal async Task DeleteObjectAsync_NamespacedObject_Throws(K8sObject namespacedObject, K8sClusterScopedApi sut)
         {
-            var namespacedIdentifiers = K8sObjectIdentifiers.Create(namespacedObject, serverHost);
+            var namespacedIdentifiers = K8sObjectIdentifiers.Create(namespacedObject);
 
             await Invoking(() => sut.DeleteObjectAsync(namespacedIdentifiers, default))
                 .Should()

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Api/K8sNamespacedApiTests.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Api/K8sNamespacedApiTests.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Nodes;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using AutoFixture.Xunit2;
-using Azure.Deployments.Extensibility.Extensions.Kubernetes.Models;
-using System.Text.Json.Nodes;
-using FluentAssertions;
-using static FluentAssertions.FluentActions;
 using Azure.Deployments.Extensibility.AspNetCore.Exceptions;
 using Azure.Deployments.Extensibility.Extensions.Kubernetes.Api;
-using Moq;
 using Azure.Deployments.Extensibility.Extensions.Kubernetes.Client;
+using Azure.Deployments.Extensibility.Extensions.Kubernetes.Models;
+using FluentAssertions;
+using Moq;
+using static FluentAssertions.FluentActions;
 
 namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Api
 {
@@ -26,9 +26,9 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Api
         }
 
         [Theory, K8sObjectWithoutNamespaceAutoData]
-        internal async Task GetObjectAsync_NamespacedNotSpecified_Throws(K8sObject objectWithoutNamespace, string serverHost, K8sNamespacedApi sut)
+        internal async Task GetObjectAsync_NamespacedNotSpecified_Throws(K8sObject objectWithoutNamespace, K8sNamespacedApi sut)
         {
-            var identifiersWithoutNamespace = K8sObjectIdentifiers.Create(objectWithoutNamespace, serverHost);
+            var identifiersWithoutNamespace = K8sObjectIdentifiers.Create(objectWithoutNamespace);
 
             await Invoking(() => sut.GetObjectAsync(identifiersWithoutNamespace, default))
                 .Should()
@@ -36,9 +36,9 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Api
         }
 
         [Theory, K8sObjectWithoutNamespaceAutoData]
-        internal async Task DeleteObjectAsync_NamespacedNotSpecified_Throws(K8sObject objectWithoutNamespace, string serverHost, K8sNamespacedApi sut)
+        internal async Task DeleteObjectAsync_NamespacedNotSpecified_Throws(K8sObject objectWithoutNamespace, K8sNamespacedApi sut)
         {
-            var identifiersWithoutNamespace = K8sObjectIdentifiers.Create(objectWithoutNamespace, serverHost);
+            var identifiersWithoutNamespace = K8sObjectIdentifiers.Create(objectWithoutNamespace);
 
             await Invoking(() => sut.DeleteObjectAsync(identifiersWithoutNamespace, default))
                 .Should()

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/KubernetesExtension.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/KubernetesExtension.cs
@@ -111,7 +111,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes
 
             var identifiers = ModelMapper.MapToK8sObjectIdentifiers(resourceReference.Identifiers);
 
-            // This can only be invoked by Deployment Stacks. ServerHostHash must be preserved
+            // This can only be invoked by Deployment Stacks. ConfigId must be preserved
             // to ensure that the operation is performed on the correct cluster.
             if (resourceReference.ConfigId is null)
             {
@@ -120,7 +120,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes
                     Error = new()
                     {
                         Code = "InvalidConfigId",
-                        Message = "The resource reference is missing the config ID.",
+                        Message = "The resource reference is missing a config ID.",
                     },
                 });
             }

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Models/K8sObjectIdentifiers.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Models/K8sObjectIdentifiers.cs
@@ -1,46 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Deployments.Extensibility.Extensions.Kubernetes.Models;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Models
 {
-    internal record K8sObjectIdentifiers(string Name, string? Namespace, string? ServerHostHash)
+    internal record K8sObjectIdentifiers(string Name, string? Namespace)
     {
-        public static K8sObjectIdentifiers Create(K8sObject k8sObject, string serverHost)
-        {
-            var serverHostHash = CalculateServerHostHash(serverHost, k8sObject.Name);
+        public static K8sObjectIdentifiers Create(K8sObject k8sObject) => new(k8sObject.Name, k8sObject.Namespace);
 
-            return new(k8sObject.Name, k8sObject.Namespace, serverHostHash);
-        }
+        public static string CalculateServerHostHash(string serverOrigin) => Hash(Encoding.UTF8.GetBytes(serverOrigin));
 
-        public bool MatchesServerHost(string serverHost)
-        {
-            var serverHostHash = CalculateServerHostHash(serverHost, this.Name);
-
-            return string.Equals(this.ServerHostHash, serverHostHash, StringComparison.Ordinal);
-        }
-
-        private static string CalculateServerHostHash(string serverOrigin, string name)
-        {
-            var serverOriginBytes = Encoding.UTF8.GetBytes(serverOrigin);
-            var nameBytes = Encoding.UTF8.GetBytes(name);
-
-            return Hash(serverOriginBytes, nameBytes);
-        }
-
-        private static string Hash(byte[] data, byte[] salt)
-        {
-            var saltedData = new byte[data.Length + salt.Length];
-            data.CopyTo(saltedData, 0);
-            salt.CopyTo(saltedData, data.Length);
-
-            return Convert.ToHexString(SHA256.HashData(saltedData));
-        }
+        private static string Hash(byte[] data) => Convert.ToHexString(SHA256.HashData(data));
     }
-    
 }

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Models/ModelMapper.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Models/ModelMapper.cs
@@ -29,7 +29,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Models
             return new(group, version, kind);
         }
 
-        public static Resource MapToResource(K8sObjectIdentifiers identifiers, K8sObject k8sObject)
+        public static Resource MapToResource(K8sObjectIdentifiers identifiers, K8sObject k8sObject, string configId)
         {
             var (group, version, kind) = k8sObject.GroupVersionKind;
             var resourceType = string.IsNullOrEmpty(group) ? $"core/{kind}" : $"{group}/{kind}";
@@ -40,6 +40,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Models
                 ApiVersion = version,
                 Identifiers = MapToResourceIdentifiers(identifiers),
                 Properties = k8sObject.Body,
+                ConfigId = configId
             };
         }
 
@@ -48,9 +49,8 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Models
             var metadataObject = identifiers["metadata"]?.AsObject() ?? throw new InvalidOperationException("Metadata must be non-null.");
             var name = metadataObject["name"]?.GetValue<string>() ?? throw new InvalidOperationException("Name must be non-null.");
             var @namespace = metadataObject["namespace"]?.GetValue<string>();
-            var serverHostHash = identifiers["serverHostHash"]?.GetValue<string>();
 
-            return new(name, @namespace, serverHostHash);
+            return new(name, @namespace);
         }
 
         public static JsonObject MapToResourceIdentifiers(K8sObjectIdentifiers identifiers) => new()
@@ -59,8 +59,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Models
             {
                 ["name"] = identifiers.Name,
                 ["namespace"] = identifiers.Namespace,
-            },
-            ["serverHostHash"] = identifiers.ServerHostHash,
+            }
         };
     }
 }


### PR DESCRIPTION
Moves the server host hash to a new top-level field of the resource specification called "ConfigId". This property is case-sensitive and is an ID calculated by the extension to uniquely identify the deployment target (the cluster). This is returned by the resource GET & PUT endpoints. This config ID must be provided to the DELETE endpoint. The extension will compare the config ID it receives to the config ID computed from the configuration passed to it. If there is a mismatch, the extension will not delete the resource.

The primary purpose of the config ID field is to stop unintended deletions from occurring from deployment stacks. The user will provide instructions on how to retrieve the secret portion of the extension config to stacks. If a secret changes between the time the resource is created to the time the resource is deleted, stacks will still attempt to delete the resource and the extension will block the request depending on how the config ID is calculated.