### PR TITLE
Change `kubeConfig` to `kubeconfig`

### DIFF
--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integration/TestFixtures/K8sResourceSpecification.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integration/TestFixtures/K8sResourceSpecification.cs
@@ -11,7 +11,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integratio
 {
     public record K8sResourceSpecification : ResourceSpecification
     {
-        private readonly static string Base64EncodedKubeConfig = LoadContentAsBase64EncodedString();
+        private readonly static string Base64EncodedKubeconfig = LoadContentAsBase64EncodedString();
 
         [SetsRequiredMembers]
         public K8sResourceSpecification(string type, string apiVersion, string propertiesJson)
@@ -21,7 +21,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integratio
                   JsonNode.Parse(propertiesJson)?.AsObject() ?? throw new ArgumentException("Argument is not a valid JSON object.", nameof(propertiesJson)),
                   new JsonObject
                   {
-                    ["kubeConfig"] = Base64EncodedKubeConfig,
+                    ["kubeconfig"] = Base64EncodedKubeconfig,
                   })
         {
         }
@@ -35,8 +35,8 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Integratio
         private static string LoadContentAsBase64EncodedString()
         {
             var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var kubeConfigPath = Path.Combine(homeDirectory, ".kube", "config");
-            var bytes = File.ReadAllBytes(kubeConfigPath);
+            var kubeconfigPath = Path.Combine(homeDirectory, ".kube", "config");
+            var bytes = File.ReadAllBytes(kubeconfigPath);
 
             return Convert.ToBase64String(bytes);
         }

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/KubernetesExtensionTests.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/KubernetesExtensionTests.cs
@@ -43,7 +43,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit
                 .With(
                     x => x.Config, new JsonObject
                     {
-                        ["kubeConfig"] = fixture.Create<string>()
+                        ["kubeconfig"] = fixture.Create<string>()
                     })
                 .With(x => x.ConfigId, (string?)null)
                 .Create();
@@ -82,7 +82,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit
                 })
                 .With(x => x.Config, new JsonObject
                 {
-                    ["kubeConfig"] = fixture.Create<string>()
+                    ["kubeconfig"] = fixture.Create<string>()
                 })
                 .With(x => x.ConfigId, fixture.Create<string>())
                 .Create();

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Validation/K8sResourceReferenceValidatorTests.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Validation/K8sResourceReferenceValidatorTests.cs
@@ -57,7 +57,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Valid
 
             errorDetails[0].Code.Should().Be("InvalidApiVersion");
             errorDetails[1].Code.Should().Be("InvalidConfig");
-            errorDetails[1].Message.Should().Be(@"Required properties [""kubeConfig""] are not present.");
+            errorDetails[1].Message.Should().Be(@"Required properties [""kubeconfig""] are not present.");
         }
 
         [Theory, AutoData]
@@ -107,7 +107,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Valid
                 })
                 .With(x => x.Config, new JsonObject()
                 {
-                    ["kubeConfig"] = "kubeConfig",
+                    ["kubeconfig"] = "kubeconfig",
                 })
                 .Create();
 

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Validation/K8sResourceSpecificationValidatorTests.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit/Validation/K8sResourceSpecificationValidatorTests.cs
@@ -57,7 +57,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Valid
 
             errorDetails[0].Code.Should().Be("InvalidApiVersion");
             errorDetails[1].Code.Should().Be("InvalidConfig");
-            errorDetails[1].Message.Should().Be(@"Required properties [""kubeConfig""] are not present.");
+            errorDetails[1].Message.Should().Be(@"Required properties [""kubeconfig""] are not present.");
         }
 
         [Theory, AutoData]
@@ -107,7 +107,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Tests.Unit.Valid
                 })
                 .With(x => x.Config, new JsonObject()
                 {
-                    ["kubeConfig"] = "kubeConfig",
+                    ["kubeconfig"] = "kubeconfig",
                 })
                 .Create();
 

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Client/K8sClientFactory.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Client/K8sClientFactory.cs
@@ -17,11 +17,11 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Client
 
             try
             {
-                var kubeConfig = config["kubeConfig"]?.GetValue<string>() ?? throw new InvalidOperationException("Expected kubeConfig to be non-null.");
-                var kubeConfigBytes = Convert.FromBase64String(kubeConfig);
-                var kubeConfigStream = new MemoryStream(kubeConfigBytes);
+                var kubeconfig = config["kubeconfig"]?.GetValue<string>() ?? throw new InvalidOperationException("Expected kubeconfig to be non-null.");
+                var kubeconfigBytes = Convert.FromBase64String(kubeconfig);
+                var kubeconfigStream = new MemoryStream(kubeconfigBytes);
                 var currentContext = config["context"]?.GetValue<string>();
-                var clientConfiguration = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeConfigStream, currentContext: currentContext);
+                var clientConfiguration = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeconfigStream, currentContext: currentContext);
 
                 if (config["namespace"]?.GetValue<string>() is { } namespaceOverride)
                 {
@@ -34,7 +34,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes.Client
             }
             catch (KubeConfigException exception)
             {
-                throw new ErrorResponseException("InvalidKubeConfig", exception.Message, JsonPointer.Create("config", "kubeConfig"));
+                throw new ErrorResponseException("InvalidKubeconfig", exception.Message, JsonPointer.Create("config", "kubeconfig"));
             }
         }
     }

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/KubernetesExtension.cs
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/KubernetesExtension.cs
@@ -177,7 +177,7 @@ namespace Azure.Deployments.Extensibility.Extensions.Kubernetes
                     Error = new()
                     {
                         Code = "ClusterMismatch",
-                        Message = "The referenced Kubernetes object cannot be deleted because it may be deployed to a different cluster. Please verify that you are using the correct kubeConfig file and context.",
+                        Message = "The referenced Kubernetes object cannot be deleted because it may be deployed to a different cluster. Please verify that you are using the correct kubeconfig file and context.",
                     },
                 });
 

--- a/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Validation/Schemas/K8sResourceConfig.schema.json
+++ b/src/Azure.Deployments.Extensibility.Extensions.Kubernetes/Validation/Schemas/K8sResourceConfig.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "kubeConfig": {
+    "kubeconfig": {
       "type": "string"
     },
     "context": {
@@ -12,5 +12,5 @@
       "type": ["string", "null"]
     }
   },
-  "required": ["kubeConfig"]
+  "required": ["kubeconfig"]
 }

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration/Fixtures/Customizations/FileSystemKubernetesConfigCustomization.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration/Fixtures/Customizations/FileSystemKubernetesConfigCustomization.cs
@@ -8,7 +8,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
 {
     public class FileSystemKubernetesConfigCustomization : ICustomization
     {
-        private static readonly byte[] KubeConfig = LoadKubeConfig();
+        private static readonly byte[] Kubeconfig = LoadKubeconfig();
 
         private readonly string @namespace;
 
@@ -21,16 +21,16 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Integration
         {
             fixture.Customize<KubernetesConfig>(composer => composer
                 .With(x => x.Namespace, this.@namespace)
-                .With(x => x.KubeConfig, KubeConfig)
+                .With(x => x.Kubeconfig, Kubeconfig)
                 .With(x => x.Context, value: null));
         }
 
-        private static byte[] LoadKubeConfig()
+        private static byte[] LoadKubeconfig()
         {
             var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var kubeConfigPath = Path.Combine(homeDirectory, ".kube", "config");
+            var kubeconfigPath = Path.Combine(homeDirectory, ".kube", "config");
 
-            return File.ReadAllBytes(kubeConfigPath);
+            return File.ReadAllBytes(kubeconfigPath);
         }
     }
 }

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Extensions/ExtensibilityOperationRequestExtensionsTests.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Extensions/ExtensibilityOperationRequestExtensionsTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
         }
 
         [Theory, ClusterRequestAutoData]
-        public async Task ProcessAsync_InvalidKubeConfig_ThrowsException(V1APIResourceList apiResourcesWithArbitraryKind, ExtensibilityOperationRequest request, Fixture fixture)
+        public async Task ProcessAsync_InvalidKubeconfig_ThrowsException(V1APIResourceList apiResourcesWithArbitraryKind, ExtensibilityOperationRequest request, Fixture fixture)
         {
             await using var server = await MockKubernetesApiServer.StartAsync(this.testOutput, httpContext =>
                 httpContext.Response.WriteAsJsonAsync(apiResourcesWithArbitraryKind));
@@ -38,7 +38,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             var importConfig = new Dictionary<string, JsonElement>
             {
                 ["namespace"] = fixture.Create<string>().AsJsonElement(),
-                ["kubeConfig"] = fixture.Create<string>().AsJsonElement(),
+                ["kubeconfig"] = fixture.Create<string>().AsJsonElement(),
             };
 
             var sut = request with
@@ -56,8 +56,8 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             var errors = assertion.Which.Errors.ToArray();
 
             errors.Should().HaveCount(1);
-            errors[0].Code.Should().Be("InvalidKubeConfig");
-            errors[0].Target.ToString().Should().Be("/import/config/kubeConfig");
+            errors[0].Code.Should().Be("InvalidKubeconfig");
+            errors[0].Target.ToString().Should().Be("/import/config/kubeconfig");
             errors[0].Message.ToString().Should().Be("Value must be a Base64-encoded string.");
         }
 
@@ -67,8 +67,8 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             await using var server = await MockKubernetesApiServer.StartAsync(this.testOutput, httpContext =>
                 httpContext.Response.WriteAsJsonAsync(apiResourcesWithArbitraryKind));
 
-            var kubeConfig = fixture.Create<string>();
-            var sut = server.InjectKubeConfig(request, kubeConfig);
+            var kubeconfig = fixture.Create<string>();
+            var sut = server.InjectKubeconfig(request, kubeconfig);
 
             var assertion = await FluentActions.Invoking(async () => await sut.ProcessAsync(CancellationToken.None))
                 .Should()
@@ -87,7 +87,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             await using var server = await MockKubernetesApiServer.StartAsync(this.testOutput, httpContext =>
                 httpContext.Response.WriteAsJsonAsync(apiResourcesWithArbitraryKind));
 
-            var sut = server.InjectKubeConfig(request);
+            var sut = server.InjectKubeconfig(request);
 
             var assertion = await FluentActions.Invoking(async () => await sut.ProcessAsync(CancellationToken.None))
                 .Should()
@@ -111,7 +111,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             await using var server = await MockKubernetesApiServer.StartAsync(this.testOutput, httpContext =>
                 httpContext.Response.WriteAsJsonAsync(apiResourceList));
 
-            var sut = server.InjectKubeConfig(request);
+            var sut = server.InjectKubeconfig(request);
 
             var assertion = await FluentActions.Invoking(async () => await sut.ProcessAsync(CancellationToken.None))
                 .Should()
@@ -135,7 +135,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             await using var server = await MockKubernetesApiServer.StartAsync(this.testOutput, httpContext =>
                 httpContext.Response.WriteAsJsonAsync(apiResourceList));
 
-            var sut = server.InjectKubeConfig(request);
+            var sut = server.InjectKubeconfig(request);
 
             var resource = await sut.ProcessAsync(CancellationToken.None);
 
@@ -152,7 +152,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Extens
             await using var server = await MockKubernetesApiServer.StartAsync(this.testOutput, httpContext =>
                 httpContext.Response.WriteAsJsonAsync(apiResourceList));
 
-            var sut = server.InjectKubeConfig(request);
+            var sut = server.InjectKubeconfig(request);
 
             var resource = await sut.ProcessAsync(CancellationToken.None);
 

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Fixtures/Customizations/EmptyKubernetesConfigCustomization.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Fixtures/Customizations/EmptyKubernetesConfigCustomization.cs
@@ -12,7 +12,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Fixtur
         public void Customize(IFixture fixture)
         {
             fixture.Customize<KubernetesConfig>(composer => composer
-                .With(x => x.KubeConfig, Array.Empty<byte>())
+                .With(x => x.Kubeconfig, Array.Empty<byte>())
                 .With(x => x.Context, value: null));
         }
     }

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/KubernetesProviderTests.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/KubernetesProviderTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => httpContext.Response.WriteAsJsonAsync(request.Resource.Properties));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.DeleteAsync(request, CancellationToken.None);
 
@@ -58,7 +58,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => httpContext.Response.WriteAsJsonAsync(request.Resource.Properties));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.DeleteAsync(request, CancellationToken.None);
 
@@ -79,7 +79,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => httpContext.Response.WriteAsync("{}"));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.GetAsync(request, CancellationToken.None);
 
@@ -100,7 +100,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => httpContext.Response.WriteAsync("{}"));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.GetAsync(request, CancellationToken.None);
 
@@ -121,7 +121,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => Task.Run(() => { httpContext.Response.StatusCode = 404; }));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.PreviewSaveAsync(request, CancellationToken.None);
 
@@ -147,7 +147,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsync("{}"),
                 HttpContext => HttpContext.Response.WriteAsJsonAsync(true));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.PreviewSaveAsync(request, CancellationToken.None);
 
@@ -168,7 +168,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 HttpContext => HttpContext.Response.WriteAsJsonAsync(true));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.PreviewSaveAsync(request, CancellationToken.None);
 
@@ -190,7 +190,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => httpContext.Response.WriteAsync("{}"));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.SaveAsync(request, CancellationToken.None);
 
@@ -211,7 +211,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit
                 httpContext => httpContext.Response.WriteAsJsonAsync(apiResourceList),
                 httpContext => httpContext.Response.WriteAsync("{}"));
 
-            request = server.InjectKubeConfig(request);
+            request = server.InjectKubeconfig(request);
 
             var response = await sut.SaveAsync(request, CancellationToken.None);
 

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Mocks/MockKubernetesApiServer.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit/Mocks/MockKubernetesApiServer.cs
@@ -69,9 +69,9 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Tests.Unit.Mocks
             return new(app);
         }
 
-        public ExtensibilityOperationRequest InjectKubeConfig(ExtensibilityOperationRequest request, string? kubeConfig = null)
+        public ExtensibilityOperationRequest InjectKubeconfig(ExtensibilityOperationRequest request, string? kubeconfig = null)
         {
-            kubeConfig ??= $@"
+            kubeconfig ??= $@"
 apiVersion: v1
 clusters:
 - cluster:
@@ -91,7 +91,7 @@ kind: Config
             {
                 Config = import.Config with
                 {
-                    KubeConfig = Encoding.UTF8.GetBytes(kubeConfig),
+                    Kubeconfig = Encoding.UTF8.GetBytes(kubeconfig),
                 },
             };
 

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes/Extensions/ExtensibilityOperationRequestExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes/Extensions/ExtensibilityOperationRequestExtensions.cs
@@ -65,12 +65,12 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Extensions
 
         private static ExtensibilityOperationRequest<KubernetesConfig, KubernetesResourceProperties> Validate(ExtensibilityOperationRequest request)
         {
-            // Validate kubeConfig format.
-            if (request.Import.Config.TryGetProperty("kubeConfig", out var kubeConfig) && !kubeConfig.GetString().IsBase64Encoded())
+            // Validate kubeconfig format.
+            if (request.Import.Config.TryGetProperty("kubeconfig", out var kubeconfig) && !kubeconfig.GetString().IsBase64Encoded())
             {
                 throw new ExtensibilityException(
-                    "InvalidKubeConfig",
-                    request.Import.GetJsonPointer(x => x.Config).Combine("kubeConfig"),
+                    "InvalidKubeconfig",
+                    request.Import.GetJsonPointer(x => x.Config).Combine("kubeconfig"),
                     @$"Value must be a Base64-encoded string.");
             }
 
@@ -86,7 +86,7 @@ namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Extensions
             try
             {
                 return await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(
-                    new MemoryStream(import.Config.KubeConfig),
+                    new MemoryStream(import.Config.Kubeconfig),
                     currentContext: import.Config.Context);
             }
             catch (Exception exception)

--- a/src/Azure.Deployments.Extensibility.Providers.Kubernetes/Models/KubernetesConfig.cs
+++ b/src/Azure.Deployments.Extensibility.Providers.Kubernetes/Models/KubernetesConfig.cs
@@ -5,12 +5,12 @@ using Json.Schema;
 
 namespace Azure.Deployments.Extensibility.Providers.Kubernetes.Models
 {
-    public record KubernetesConfig(string Namespace, byte[] KubeConfig, string? Context)
+    public record KubernetesConfig(string Namespace, byte[] Kubeconfig, string? Context)
     {
         public readonly static JsonSchema Schema = new JsonSchemaBuilder()
             .Properties(
                 ("namespace", new JsonSchemaBuilder().Type(SchemaValueType.String)),
-                ("kubeConfig", new JsonSchemaBuilder().Type(SchemaValueType.String)),
+                ("kubeconfig", new JsonSchemaBuilder().Type(SchemaValueType.String)),
                 ("context", new JsonSchemaBuilder().Type(SchemaValueType.String, SchemaValueType.Null)))
             .AdditionalProperties(false);
     }


### PR DESCRIPTION
`kubeconfig` (all lowercase) is the standard convention. For k8s v2 extension we should use it.