### PR TITLE
Implement kubernetes DeploymentTargetNotFound handling.

### DIFF
--- a/src/Azure.Deployments.Extensibility.Core/Exceptions/ExtensibilityException.cs
+++ b/src/Azure.Deployments.Extensibility.Core/Exceptions/ExtensibilityException.cs
@@ -23,5 +23,15 @@ namespace Azure.Deployments.Extensibility.Core.Exceptions
         }
 
         public IEnumerable<ExtensibilityError> Errors { get; }
+
+        public override string Message
+        {
+            get
+            {
+                var firstError = this.Errors.FirstOrDefault();
+
+                return firstError is not null ? $"{firstError.Code}: {firstError.Message}" : string.Empty;
+            }
+        }
     }
 }


### PR DESCRIPTION
Need extensibility host to return an error code of "DeploymentTargetNotFound" when the AKS cluster is deleted for a stack's extensible resource.