### PR TITLE
ci: pin contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
The sibling `docs.yml` workflow already declares `permissions: { contents: read }` at the top level. `ci.yml` doesn't, so it currently runs with the repo-wide default `GITHUB_TOKEN` scope.

CI here only does dotnet build/test/pack, uploads a NuGet artifact, and a codecov upload — no GitHub API writes. Adding the same `contents: read` block to `ci.yml` keeps it consistent with `docs.yml` and tightens the token scope.

YAML re-parsed locally with `yaml.safe_load`. No behavior change.