### PR TITLE
Preview contract updates.

### DIFF
--- a/docs/contract/contract.md
+++ b/docs/contract/contract.md
@@ -105,7 +105,8 @@ model ResourcePreviewSpecification extends ResourceSpecification {
 }
 
 model ResourcePreviewSpecificationMetadata {
-  unevaluated: JsonPointer[];  // paths to properties with unevaluated ARM expressions
+  unevaluated: JsonPointer[];  // paths to property values with unevaluated ARM expressions
+  unevaluatedPropertyNames: JsonPointer[];  // paths to property names with unevaluated ARM expressions
 }
 ```
 
@@ -152,6 +153,7 @@ model ResourcePreviewMetadata {
   unknown?: JsonPointer[];
   calculated?: JsonPointer[];
   unevaluated?: JsonPointer[];
+  unevaluatedPropertyNames?: JsonPointer[];
 }
 ```
 

--- a/docs/contract/contract.md
+++ b/docs/contract/contract.md
@@ -106,7 +106,6 @@ model ResourcePreviewSpecification extends ResourceSpecification {
 
 model ResourcePreviewSpecificationMetadata {
   unevaluated: JsonPointer[];  // paths to property values with unevaluated ARM expressions
-  unevaluatedPropertyNames: JsonPointer[];  // paths to property names with unevaluated ARM expressions
 }
 ```
 
@@ -153,7 +152,6 @@ model ResourcePreviewMetadata {
   unknown?: JsonPointer[];
   calculated?: JsonPointer[];
   unevaluated?: JsonPointer[];
-  unevaluatedPropertyNames?: JsonPointer[];
 }
 ```
 

--- a/docs/contract/preview-operation.md
+++ b/docs/contract/preview-operation.md
@@ -126,13 +126,13 @@ The response must represent the resource state as if the create or update operat
 
 ### Response Requirements
 
-| Requirement | Details |
-|-------------|---------|
-| Read-only properties | Include properties managed by the service (e.g., `provisioningState`, `id`). |
-| Default values | Fill in properties that the service would assign defaults to. |
-| Write-only properties | Exclude secrets such as passwords and connection strings. |
-| Unevaluated expressions | Echo back the raw expression string as-is. |
-| Identifiers | Include the `identifiers` object with the best available values. |
+| Requirement             | Details                                                                      |
+|-------------------------|------------------------------------------------------------------------------|
+| Read-only properties    | Include properties managed by the service (e.g., `provisioningState`, `id`). |
+| Default values          | Fill in properties that the service would assign defaults to.                |
+| Write-only properties   | Exclude secrets such as passwords and connection strings.                    |
+| Unevaluated expressions | Echo back the raw expression string as-is.                                   |
+| Identifiers             | Include the `identifiers` object with the best available values.             |
 
 ## Preview Metadata
 
@@ -183,6 +183,8 @@ Properties whose values are computed at operation time and would change if the o
 ### `unknown`
 
 Properties whose values cannot be determined at preview time. This typically applies when a value depends on an unevaluated expression or external state that is unavailable during preview.
+**It is essential that if the extension cannot compute the resource `identifiers` and/or `configId`, these property
+paths must be present in the response's `metadata.unknown` as it affects how what-if computes a change for the resource.**
 
 **Example:** An `email` that depends on a domain configuration resource that has not been deployed yet.
 
@@ -288,6 +290,7 @@ If the request includes a `config` object, the extension must:
 
 1. **Echo back the configuration** in the response, excluding any secret properties. Any property not echoed back is treated as a secret by the deployment engine.
 2. **Return a `configId`**, a value that uniquely identifies the deployment control plane. The format is determined by the extension (e.g., a hash of the endpoint URL).
+    - **If `configId` cannot be calculated, the extension must return a null configId include its JSON pointer in `metadata.unknown` in its response.**
 3. **Validate the `configId`** if one is provided in the request.
 
 ## End-to-End Examples

--- a/docs/contract/preview-operation.md
+++ b/docs/contract/preview-operation.md
@@ -38,13 +38,11 @@ model ResourcePreviewSpecification extends ResourceSpecification {
 
 model ResourcePreviewSpecificationMetadata {
   unevaluated: JsonPointer[];
-  unevaluatedPropertyNames: JsonPointer[];
 }
 ```
 
 The `ResourcePreviewSpecification` extends the standard `ResourceSpecification` with an optional `metadata` object. 
 When present, `metadata.unevaluated` lists the JSON Pointer paths to properties whose values are unresolved ARM template language expressions.
-When present, `metadata.unevaluatedPropertyNames` lists the JSON Pointer paths to properties whose names are unresolved ARM template language expressions.
 
 ## Unevaluated Expressions
 
@@ -119,7 +117,6 @@ model ResourcePreviewMetadata {
   unknown?: JsonPointer[];
   calculated?: JsonPointer[];
   unevaluated?: JsonPointer[];
-  unevaluatedPropertyNames?: JsonPointer[];
 }
 ```
 

--- a/docs/contract/preview-operation.md
+++ b/docs/contract/preview-operation.md
@@ -543,12 +543,83 @@ The deployment engine calls get to retrieve the resource's current state.
 }
 ```
 
-### Step 3: Process States Using Preview Metadata
+### Step 3: Diff and Produce What-If Output
 
-> [!NOTE]
-> This section is under development and will be finalized in a future update.
+In this scenario, there are no partially unevaluated or unknown resource identifiers or extension configuration, so
+What-If will take the preview results and the current state to produce a "Definite Modify" change for this resource.
 
-### Step 4: Diff and Produce What-If Output
+**What-If response:**
 
-> [!NOTE]
-> This section is under development and will be finalized in a future update.
+```json
+{
+  "properties": {
+    "changes": [
+      {
+        "changeType": "Modify",
+        "extension": {
+          "name": "Contoso",
+          "version": "2.0.0",
+          "configId": "sha256:a1b2c3d4",
+          "config": {
+            "endpoint": "https://hr-api.contoso.com"
+          }
+        },
+        "type": "Contoso.HR/employees",
+        "identifiers": {
+          "employeeId": "emp-00042"
+        },
+        "before": {
+          "Type": "Contoso.HR/employees",
+          "ApiVersion": "2024-04-01",
+          "Properties": {
+            "firstName": "John",
+            "lastName": "Smith",
+            "department": "Engineering",
+            "role": "Engineer",
+            "employeeId": "emp-00042",
+            "onboardingState": "Succeeded",
+            "startDate": "2024-02-01",
+            "badgeNumber": "B-1234",
+            "email": "john.smith@contoso.com"
+          }
+        },
+        "after": {
+          "Type": "Contoso.HR/employees",
+          "ApiVersion": "2024-04-01",
+          "Properties": {
+            "firstName": "John",
+            "lastName": "Smith",
+            "department": "Marketing",
+            "role": "Manager",
+            "employeeId": "emp-00042",
+            "onboardingState": "Succeeded",
+            "startDate": "2024-02-01",
+            "badgeNumber": "B-5678",
+            "email": "john.smith@contoso.com"
+          }
+        },
+        "delta": [
+          {
+            "path": "properties.department",
+            "propertyChangeType": "Modify",
+            "before": "Engineering",
+            "after": "Marketing"
+          },
+          {
+            "path": "properties.role",
+            "propertyChangeType": "Modify",
+            "before": "Engineer",
+            "after": "Manager"
+          },
+          {
+            "path": "properties.badgeNumber",
+            "propertyChangeType": "Modify",
+            "before": "B-1234",
+            "after": "B-5678"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/docs/contract/preview-operation.md
+++ b/docs/contract/preview-operation.md
@@ -119,6 +119,7 @@ model ResourcePreviewMetadata {
   unknown?: JsonPointer[];
   calculated?: JsonPointer[];
   unevaluated?: JsonPointer[];
+  unevaluatedPropertyNames?: JsonPointer[];
 }
 ```
 
@@ -290,7 +291,7 @@ If the request includes a `config` object, the extension must:
 
 1. **Echo back the configuration** in the response, excluding any secret properties. Any property not echoed back is treated as a secret by the deployment engine.
 2. **Return a `configId`**, a value that uniquely identifies the deployment control plane. The format is determined by the extension (e.g., a hash of the endpoint URL).
-    - **If `configId` cannot be calculated, the extension must return a null configId include its JSON pointer in `metadata.unknown` in its response.**
+    - **If `configId` cannot be calculated, the extension should omit `configId` or set it to null and include its JSON pointer in `metadata.unknown` in its response.**
 3. **Validate the `configId`** if one is provided in the request.
 
 ## End-to-End Examples

--- a/docs/contract/preview-operation.md
+++ b/docs/contract/preview-operation.md
@@ -502,7 +502,8 @@ The deployment engine calls preview with the desired state from the template.
     "onboardingState": "Succeeded",
     "startDate": "2024-02-01",
     "badgeNumber": "B-5678",
-    "email": "john.smith@contoso.com"
+    "email": "john.smith@contoso.com",
+    "lastModified": "2026-05-27T00:00:00Z"
   },
   "config": {
     "endpoint": "https://hr-api.contoso.com"
@@ -511,7 +512,7 @@ The deployment engine calls preview with the desired state from the template.
   "metadata": {
     "readOnly": ["/properties/employeeId", "/properties/onboardingState", "/properties/email"],
     "immutable": ["/properties/startDate"],
-    "calculated": ["/properties/badgeNumber"]
+    "calculated": ["/properties/badgeNumber", "/properties/lastModified"]
   }
 }
 ```
@@ -538,7 +539,8 @@ The deployment engine calls get to retrieve the resource's current state.
     "onboardingState": "Succeeded",
     "startDate": "2024-02-01",
     "badgeNumber": "B-1234",
-    "email": "john.smith@contoso.com"
+    "email": "john.smith@contoso.com",
+    "lastUpdated": "2025-03-12T00:00:00Z"
   },
   "config": {
     "endpoint": "https://hr-api.contoso.com"
@@ -551,6 +553,12 @@ The deployment engine calls get to retrieve the resource's current state.
 
 In this scenario, there are no partially unevaluated or unknown resource identifiers or extension configuration, so
 What-If will take the preview results and the current state to produce a "Definite Modify" change for this resource.
+
+In the preview result, it can see that the `lastModified` and `badgeNumber` properies are calculated properties. This 
+means that their values are calculated on demand and may change between the preview time and submission time. Properties
+that are calculated on demand are typically considered as noise in What-If output, meaning it's generally not useful 
+to see them. If a deployments user wishes to collect badge numbers, they should do so after submitting the
+update and not depend on What-if for those values. In the what-if output below, those properties are omitted.
 
 **What-If response:**
 
@@ -583,7 +591,6 @@ What-If will take the preview results and the current state to produce a "Defini
             "employeeId": "emp-00042",
             "onboardingState": "Succeeded",
             "startDate": "2024-02-01",
-            "badgeNumber": "B-1234",
             "email": "john.smith@contoso.com"
           }
         },
@@ -598,7 +605,6 @@ What-If will take the preview results and the current state to produce a "Defini
             "employeeId": "emp-00042",
             "onboardingState": "Succeeded",
             "startDate": "2024-02-01",
-            "badgeNumber": "B-5678",
             "email": "john.smith@contoso.com"
           }
         },
@@ -614,12 +620,6 @@ What-If will take the preview results and the current state to produce a "Defini
             "propertyChangeType": "Modify",
             "before": "Engineer",
             "after": "Manager"
-          },
-          {
-            "path": "properties.badgeNumber",
-            "propertyChangeType": "Modify",
-            "before": "B-1234",
-            "after": "B-5678"
           }
         ]
       }

--- a/docs/contract/preview-operation.md
+++ b/docs/contract/preview-operation.md
@@ -38,10 +38,13 @@ model ResourcePreviewSpecification extends ResourceSpecification {
 
 model ResourcePreviewSpecificationMetadata {
   unevaluated: JsonPointer[];
+  unevaluatedPropertyNames: JsonPointer[];
 }
 ```
 
-The `ResourcePreviewSpecification` extends the standard `ResourceSpecification` with an optional `metadata` object. When present, `metadata.unevaluated` lists the JSON Pointer paths to properties whose values are unresolved ARM template language expressions.
+The `ResourcePreviewSpecification` extends the standard `ResourceSpecification` with an optional `metadata` object. 
+When present, `metadata.unevaluated` lists the JSON Pointer paths to properties whose values are unresolved ARM template language expressions.
+When present, `metadata.unevaluatedPropertyNames` lists the JSON Pointer paths to properties whose names are unresolved ARM template language expressions.
 
 ## Unevaluated Expressions
 
@@ -191,15 +194,36 @@ Properties whose values cannot be determined at preview time. This typically app
 }
 ```
 
+**Example:** The `identifiers` and `configId` of the resource cannot be determined at preview time.
+
+```json
+{
+  "metadata": {
+    "unknown": ["/identifiers", "/configId"]
+  }
+}
+```
+
 ### `unevaluated`
 
 Properties containing ARM template language expressions that the deployment engine could not resolve. The extension must account for every path received in the request's `metadata.unevaluated`, but should **reclassify** a path into a more specific category whenever possible. For example, if the unevaluated path points to a property the extension knows is always read-only, it should appear under `readOnly`, not `unevaluated`. Only list a path under `unevaluated` when the extension cannot determine a more specific category.
+
+**Example:** The department property is an expression that cannot be resolved.
 
 ```json
 {
   "metadata": {
     "unevaluated": ["/properties/department"]
   }
+}
+```
+
+**Example:** The `identifiers` is partially evaluated.
+```json
+{
+  "metadata": {
+    "unevaluated": ["/identifiers/name"]
+  }  
 }
 ```
 

--- a/docs/contract/v2/openapi.yaml
+++ b/docs/contract/v2/openapi.yaml
@@ -806,7 +806,9 @@ components:
           description: |-
             JSON Pointers to properties whose values cannot be determined at preview
             time (e.g., because they depend on unevaluated expressions or external
-            state).
+            state). In addition to resource properties that are unknown, if the identifiers
+            or configId cannot be determined, the extension must include the corresponding
+            JSON Pointers here as well.
         calculated:
           type: array
           items:
@@ -823,7 +825,16 @@ components:
             expressions. The extension must echo these back from the request.
             A property in `unevaluated` in the request may be reclassified in the
             response (e.g., as `readOnly` or `immutable`) if the extension can
-            determine the property's nature despite the unevaluated expression.
+            determine the property's nature despite the unevaluated expression. If the
+            extension chooses to return a property value as a language expression, such
+            as partially evaluated identifiers, the property pointer must be added here.
+        unevaluatedPropertyNames:
+          type: array
+          items:
+            $ref: '#/components/schemas/JsonPointer'
+          description: |-
+            JSON Pointers to object property names that contain unevaluated ARM template language
+            expressions. The extension must echo these back from the request.
       description: |-
         Contains metadata about a resource preview, indicating which properties
         are read-only, immutable, unknown, calculated, or unevaluated.
@@ -854,6 +865,13 @@ components:
             JSON Pointers to the properties that could not be evaluated during the
             preview. The values of these properties are ARM template expressions
             (e.g., [reference(...)]).
+        unevaluatedPropertyNames:
+          type: array
+          items:
+            $ref: '#/components/schemas/JsonPointer'
+          description: |-
+            JSON Pointers to object property names that contain unevaluated ARM template language
+            expressions. The extension must echo these back from the request.
       description: |-
         Contains metadata for a resource preview specification, indicating which
         properties could not be evaluated at the time of the preview request.

--- a/docs/contract/v2/openapi.yaml
+++ b/docs/contract/v2/openapi.yaml
@@ -828,13 +828,6 @@ components:
             determine the property's nature despite the unevaluated expression. If the
             extension chooses to return a property value as a language expression, such
             as partially evaluated identifiers, the property pointer must be added here.
-        unevaluatedPropertyNames:
-          type: array
-          items:
-            $ref: '#/components/schemas/JsonPointer'
-          description: |-
-            JSON Pointers to object property names that contain unevaluated ARM template language
-            expressions. The extension must echo these back from the request.
       description: |-
         Contains metadata about a resource preview, indicating which properties
         are read-only, immutable, unknown, calculated, or unevaluated.
@@ -856,7 +849,6 @@ components:
       type: object
       required:
         - unevaluated
-        - unevaluatedPropertyNames
       properties:
         unevaluated:
           type: array
@@ -866,13 +858,6 @@ components:
             JSON Pointers to the properties that could not be evaluated during the
             preview. The values of these properties are ARM template expressions
             (e.g., [reference(...)]).
-        unevaluatedPropertyNames:
-          type: array
-          items:
-            $ref: '#/components/schemas/JsonPointer'
-          description: |-
-            JSON Pointers to object property names that contain unevaluated ARM template language
-            expressions. The extension must echo these back from the request.
       description: |-
         Contains metadata for a resource preview specification, indicating which
         properties could not be evaluated at the time of the preview request.

--- a/docs/contract/v2/openapi.yaml
+++ b/docs/contract/v2/openapi.yaml
@@ -856,6 +856,7 @@ components:
       type: object
       required:
         - unevaluated
+        - unevaluatedPropertyNames
       properties:
         unevaluated:
           type: array

--- a/spec/core.tsp
+++ b/spec/core.tsp
@@ -190,6 +190,12 @@ model ResourcePreviewSpecificationMetadata {
    * (e.g., [reference(...)]).
    */
   unevaluated: JsonPointer[];
+  
+  /**
+   * JSON Pointers to object property names that contain unevaluated ARM template language
+   * expressions. The extension must echo these back from the request.
+   */
+  unevaluatedPropertyNames?: JsonPointer[];
 }
 
 // ===========================================================================
@@ -314,7 +320,9 @@ model ResourcePreviewMetadata {
   /**
    * JSON Pointers to properties whose values cannot be determined at preview
    * time (e.g., because they depend on unevaluated expressions or external
-   * state).
+   * state). In addition to resource properties that are unknown, if the identifiers
+   * or configId cannot be determined, the extension must include the corresponding
+   * JSON Pointers here as well.
    */
   `unknown`?: JsonPointer[];
 
@@ -329,9 +337,17 @@ model ResourcePreviewMetadata {
    * expressions. The extension must echo these back from the request.
    * A property in `unevaluated` in the request may be reclassified in the
    * response (e.g., as `readOnly` or `immutable`) if the extension can
-   * determine the property's nature despite the unevaluated expression.
+   * determine the property's nature despite the unevaluated expression. If the
+   * extension chooses to return a property value as a language expression, such
+   * as partially evaluated identifiers, the property pointer must be added here.
    */
   unevaluated?: JsonPointer[];
+
+  /**
+   * JSON Pointers to object property names that contain unevaluated ARM template language
+   * expressions. The extension must echo these back from the request.
+   */
+  unevaluatedPropertyNames?: JsonPointer[];
 }
 
 // ===========================================================================

--- a/spec/core.tsp
+++ b/spec/core.tsp
@@ -190,12 +190,12 @@ model ResourcePreviewSpecificationMetadata {
    * (e.g., [reference(...)]).
    */
   unevaluated: JsonPointer[];
-  
+
   /**
    * JSON Pointers to object property names that contain unevaluated ARM template language
    * expressions. The extension must echo these back from the request.
    */
-  unevaluatedPropertyNames?: JsonPointer[];
+  unevaluatedPropertyNames: JsonPointer[];
 }
 
 // ===========================================================================

--- a/spec/core.tsp
+++ b/spec/core.tsp
@@ -190,12 +190,6 @@ model ResourcePreviewSpecificationMetadata {
    * (e.g., [reference(...)]).
    */
   unevaluated: JsonPointer[];
-
-  /**
-   * JSON Pointers to object property names that contain unevaluated ARM template language
-   * expressions. The extension must echo these back from the request.
-   */
-  unevaluatedPropertyNames: JsonPointer[];
 }
 
 // ===========================================================================
@@ -342,12 +336,6 @@ model ResourcePreviewMetadata {
    * as partially evaluated identifiers, the property pointer must be added here.
    */
   unevaluated?: JsonPointer[];
-
-  /**
-   * JSON Pointers to object property names that contain unevaluated ARM template language
-   * expressions. The extension must echo these back from the request.
-   */
-  unevaluatedPropertyNames?: JsonPointer[];
 }
 
 // ===========================================================================

--- a/spec/http.tsp
+++ b/spec/http.tsp
@@ -20,9 +20,13 @@ using OpenAPI;
 
 @service(#{ title: "Bicep Extensibility Provider API" })
 @info(#{ version: "2.0.0" })
-@server("{endpoint}", "Extension endpoint", {
-  endpoint: string = "http://localhost:8080",
-})
+@server(
+  "{endpoint}",
+  "Extension endpoint",
+  {
+    endpoint: string = "http://localhost:8080",
+  }
+)
 namespace BicepExtensibility;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Updates the preview contract.
- Complete example of what-if on a resource.
- Add note about `configId` and `identifiers` that if they cannot be computed, their property paths should be included in the response preview metadata.