### PR TITLE
Propagate Status and Error in typed handler model mapping

### DIFF
--- a/Azure.Deployments.Extensibility.sln
+++ b/Azure.Deployments.Extensibility.sln
@@ -58,7 +58,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MagicEightBallExtension", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{01C4597C-FD7B-46C6-9649-FF3462728B00}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Deployments.Extensibility.AspNetCore.Tests.Unit", "src\Azure.Deployments.Extensibility.AspNetCore.Tests.Unit\Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj", "{513971AB-B2F3-4735-8EF8-A81813FA59B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Deployments.Extensibility.AspNetCore.Tests.Unit", "src\Azure.Deployments.Extensibility.AspNetCore.Tests.Unit\Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj", "{513971AB-B2F3-4735-8EF8-A81813FA59B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Azure.Deployments.Extensibility.sln
+++ b/Azure.Deployments.Extensibility.sln
@@ -56,6 +56,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{2E78DB
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MagicEightBallExtension", "sample\MagicEightBallExtension\MagicEightBallExtension.csproj", "{6B89B5D6-DA9D-41C9-97CC-931CADE6E96F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{01C4597C-FD7B-46C6-9649-FF3462728B00}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Deployments.Extensibility.AspNetCore.Tests.Unit", "src\Azure.Deployments.Extensibility.AspNetCore.Tests.Unit\Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj", "{513971AB-B2F3-4735-8EF8-A81813FA59B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +118,10 @@ Global
 		{6B89B5D6-DA9D-41C9-97CC-931CADE6E96F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B89B5D6-DA9D-41C9-97CC-931CADE6E96F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B89B5D6-DA9D-41C9-97CC-931CADE6E96F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{513971AB-B2F3-4735-8EF8-A81813FA59B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{513971AB-B2F3-4735-8EF8-A81813FA59B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{513971AB-B2F3-4735-8EF8-A81813FA59B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{513971AB-B2F3-4735-8EF8-A81813FA59B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -134,6 +142,7 @@ Global
 		{C0D5356F-C39C-4A4B-8573-40A5CD43E9EA} = {0AFEE13C-D656-43BF-98F1-263D71E5C04A}
 		{C4D9552F-D20A-4ED2-8E1F-5D55728ABC42} = {0AFEE13C-D656-43BF-98F1-263D71E5C04A}
 		{6B89B5D6-DA9D-41C9-97CC-931CADE6E96F} = {2E78DB9E-BB2A-4C65-8A0B-121894614981}
+		{513971AB-B2F3-4735-8EF8-A81813FA59B0} = {01C4597C-FD7B-46C6-9649-FF3462728B00}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E3073660-079C-482C-ABB4-E970087314E7}

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Deployments.Extensibility.AspNetCore\Azure.Deployments.Extensibility.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
+{
+    /// <summary>
+    /// Verifies that the typed handler base classes propagate the resource Status and Error fields
+    /// (and the resource preview Status) when mapping the strongly-typed result back to the untyped
+    /// contract. These fields back the RELO (resource-based long-running operation) flow, so dropping
+    /// them silently breaks asynchronous status polling.
+    /// </summary>
+    public class TypedResourceMappingTests
+    {
+        private static IOptions<JsonOptions> JsonOptions => Options.Create(new JsonOptions());
+
+        private static ResourceSpecification CreateSpecification() => new()
+        {
+            Type = "Test",
+            Properties = new JsonObject { ["name"] = "widget" },
+        };
+
+        private static ResourceReference CreateReference() => new()
+        {
+            Type = "Test",
+            Identifiers = new JsonObject { ["name"] = "widget" },
+        };
+
+        [Fact]
+        public async Task CreateOrUpdate_NonTerminalStatusAndError_ArePropagatedToResource()
+        {
+            var sut = new StubCreateOrUpdateHandler(JsonOptions);
+
+            var result = await ((IResourceCreateOrUpdateHandler)sut).HandleAsync(CreateSpecification(), CancellationToken.None);
+
+            result.IsT0.Should().BeTrue();
+            result.AsT0!.Status.Should().Be("Running");
+            result.AsT0!.Error!.Code.Should().Be("Simulated");
+        }
+
+        [Fact]
+        public async Task Get_StatusIsPropagatedToResource()
+        {
+            var sut = new StubGetHandler(JsonOptions);
+
+            var result = await ((IResourceGetHandler)sut).HandleAsync(CreateReference(), CancellationToken.None);
+
+            result.IsT0.Should().BeTrue();
+            result.AsT0!.Status.Should().Be("Succeeded");
+        }
+
+        [Fact]
+        public async Task Delete_StatusAndError_ArePropagatedToResource()
+        {
+            var sut = new StubDeleteHandler(JsonOptions);
+
+            var result = await ((IResourceDeleteHandler)sut).HandleAsync(CreateReference(), CancellationToken.None);
+
+            result.IsT0.Should().BeTrue();
+            result.AsT0!.Status.Should().Be("Deleting");
+            result.AsT0!.Error!.Code.Should().Be("Simulated");
+        }
+
+        [Fact]
+        public async Task Preview_StatusIsPropagatedToResourcePreview()
+        {
+            var sut = new StubPreviewHandler(JsonOptions);
+
+            var request = new ResourcePreviewSpecification
+            {
+                Type = "Test",
+                Properties = new JsonObject { ["name"] = "widget" },
+            };
+
+            var result = await ((IResourcePreviewHandler)sut).HandleAsync(request, CancellationToken.None);
+
+            result.IsT0.Should().BeTrue();
+            result.AsT0!.Status.Should().Be("Running");
+        }
+
+        public record TestProperties
+        {
+            public string? Name { get; init; }
+        }
+
+        public record TestIdentifiers
+        {
+            public string? Name { get; init; }
+        }
+
+        private sealed class StubCreateOrUpdateHandler : TypedResourceCreateOrUpdateHandler<TestProperties, TestIdentifiers>
+        {
+            public StubCreateOrUpdateHandler(IOptions<JsonOptions> jsonOptions)
+                : base(jsonOptions)
+            {
+            }
+
+            protected override Task<OneOf<TypedResource, LongRunningOperation, ErrorResponse>> HandleAsync(TypedResourceSpecification request, CancellationToken cancellationToken) =>
+                Task.FromResult<OneOf<TypedResource, LongRunningOperation, ErrorResponse>>(new TypedResource
+                {
+                    Type = request.Type,
+                    Identifiers = new TestIdentifiers { Name = "widget" },
+                    Properties = request.Properties,
+                    Status = "Running",
+                    Error = new Error { Code = "Simulated", Message = "Simulated failure." },
+                });
+        }
+
+        private sealed class StubGetHandler : TypedResourceGetHandler<TestProperties, TestIdentifiers>
+        {
+            public StubGetHandler(IOptions<JsonOptions> jsonOptions)
+                : base(jsonOptions)
+            {
+            }
+
+            protected override Task<OneOf<TypedResource?, ErrorResponse>> HandleAsync(TypedResourceReference request, CancellationToken cancellationToken) =>
+                Task.FromResult<OneOf<TypedResource?, ErrorResponse>>(new TypedResource
+                {
+                    Type = request.Type,
+                    Identifiers = new TestIdentifiers { Name = "widget" },
+                    Properties = new TestProperties { Name = "widget" },
+                    Status = "Succeeded",
+                });
+        }
+
+        private sealed class StubDeleteHandler : TypedResourceDeleteHandler<TestProperties, TestIdentifiers>
+        {
+            public StubDeleteHandler(IOptions<JsonOptions> jsonOptions)
+                : base(jsonOptions)
+            {
+            }
+
+            protected override Task<OneOf<TypedResource?, LongRunningOperation, ErrorResponse>> HandleAsync(TypedResourceReference request, CancellationToken cancellationToken) =>
+                Task.FromResult<OneOf<TypedResource?, LongRunningOperation, ErrorResponse>>(new TypedResource
+                {
+                    Type = request.Type,
+                    Identifiers = new TestIdentifiers { Name = "widget" },
+                    Properties = new TestProperties { Name = "widget" },
+                    Status = "Deleting",
+                    Error = new Error { Code = "Simulated", Message = "Simulated failure." },
+                });
+        }
+
+        private sealed class StubPreviewHandler : TypedResourcePreviewHandler<TestProperties, TestIdentifiers>
+        {
+            public StubPreviewHandler(IOptions<JsonOptions> jsonOptions)
+                : base(jsonOptions)
+            {
+            }
+
+            protected override Task<OneOf<TypedResourcePreview, ErrorResponse>> HandleAsync(TypedResourcePreviewSpecification request, CancellationToken cancellationToken) =>
+                Task.FromResult<OneOf<TypedResourcePreview, ErrorResponse>>(new TypedResourcePreview
+                {
+                    Type = request.Type,
+                    Identifiers = new TestIdentifiers { Name = "widget" },
+                    Properties = request.Properties,
+                    Status = "Running",
+                });
+        }
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
@@ -15,9 +15,9 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
 {
     /// <summary>
     /// Verifies that the typed handler base classes propagate the resource Status and Error fields
-    /// (and the resource preview Status) when mapping the strongly-typed result back to the untyped
-    /// contract. These fields back the RELO (resource-based long-running operation) flow, so dropping
-    /// them silently breaks asynchronous status polling.
+    /// (and the resource preview Status) when mapping between strongly-typed handler models and the
+    /// untyped contract models, in both directions. These fields back the RELO (resource-based
+    /// long-running operation) flow, so dropping them silently breaks asynchronous status polling.
     /// </summary>
     public class TypedResourceMappingTests
     {
@@ -36,21 +36,33 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
         };
 
         [Fact]
-        public async Task CreateOrUpdate_NonTerminalStatusAndError_ArePropagatedToResource()
+        public async Task CreateOrUpdate_NonTerminalStatus_IsPropagatedToResource()
         {
-            var sut = new StubCreateOrUpdateHandler(JsonOptions);
+            var sut = new StubCreateOrUpdateHandler(JsonOptions, status: "Running");
 
             var result = await ((IResourceCreateOrUpdateHandler)sut).HandleAsync(CreateSpecification(), CancellationToken.None);
 
             result.IsT0.Should().BeTrue();
             result.AsT0!.Status.Should().Be("Running");
+            result.AsT0!.Error.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task CreateOrUpdate_FailedStatusAndError_ArePropagatedToResource()
+        {
+            var sut = new StubCreateOrUpdateHandler(JsonOptions, status: "Failed", error: SimulatedError());
+
+            var result = await ((IResourceCreateOrUpdateHandler)sut).HandleAsync(CreateSpecification(), CancellationToken.None);
+
+            result.IsT0.Should().BeTrue();
+            result.AsT0!.Status.Should().Be("Failed");
             result.AsT0!.Error!.Code.Should().Be("Simulated");
         }
 
         [Fact]
-        public async Task Get_StatusIsPropagatedToResource()
+        public async Task Get_Status_IsPropagatedToResource()
         {
-            var sut = new StubGetHandler(JsonOptions);
+            var sut = new StubGetHandler(JsonOptions, status: "Succeeded");
 
             var result = await ((IResourceGetHandler)sut).HandleAsync(CreateReference(), CancellationToken.None);
 
@@ -59,21 +71,21 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
         }
 
         [Fact]
-        public async Task Delete_StatusAndError_ArePropagatedToResource()
+        public async Task Delete_NonTerminalStatus_IsPropagatedToResource()
         {
-            var sut = new StubDeleteHandler(JsonOptions);
+            var sut = new StubDeleteHandler(JsonOptions, status: "Deleting");
 
             var result = await ((IResourceDeleteHandler)sut).HandleAsync(CreateReference(), CancellationToken.None);
 
             result.IsT0.Should().BeTrue();
             result.AsT0!.Status.Should().Be("Deleting");
-            result.AsT0!.Error!.Code.Should().Be("Simulated");
+            result.AsT0!.Error.Should().BeNull();
         }
 
         [Fact]
-        public async Task Preview_StatusIsPropagatedToResourcePreview()
+        public async Task Preview_Status_IsPropagatedToResourcePreview()
         {
-            var sut = new StubPreviewHandler(JsonOptions);
+            var sut = new StubPreviewHandler(JsonOptions, status: "Running");
 
             var request = new ResourcePreviewSpecification
             {
@@ -87,6 +99,42 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
             result.AsT0!.Status.Should().Be("Running");
         }
 
+        [Fact]
+        public void ToTypedResource_FailedStatusAndError_ArePropagated()
+        {
+            var probe = new MappingProbe(JsonOptions);
+            var resource = new Resource
+            {
+                Type = "Test",
+                Identifiers = new JsonObject { ["name"] = "widget" },
+                Properties = new JsonObject { ["name"] = "widget" },
+                Status = "Failed",
+                Error = SimulatedError(),
+            };
+
+            var (status, error) = probe.ConvertToTyped(resource);
+
+            status.Should().Be("Failed");
+            error!.Code.Should().Be("Simulated");
+        }
+
+        [Fact]
+        public void ToTypedResourcePreview_Status_IsPropagated()
+        {
+            var probe = new MappingProbe(JsonOptions);
+            var preview = new ResourcePreview
+            {
+                Type = "Test",
+                Identifiers = new JsonObject { ["name"] = "widget" },
+                Properties = new JsonObject { ["name"] = "widget" },
+                Status = "Running",
+            };
+
+            probe.ConvertToTypedPreview(preview).Should().Be("Running");
+        }
+
+        private static Error SimulatedError() => new() { Code = "Simulated", Message = "Simulated failure." };
+
         public record TestProperties
         {
             public string? Name { get; init; }
@@ -99,9 +147,14 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
 
         private sealed class StubCreateOrUpdateHandler : TypedResourceCreateOrUpdateHandler<TestProperties, TestIdentifiers>
         {
-            public StubCreateOrUpdateHandler(IOptions<JsonOptions> jsonOptions)
+            private readonly string status;
+            private readonly Error? error;
+
+            public StubCreateOrUpdateHandler(IOptions<JsonOptions> jsonOptions, string status, Error? error = null)
                 : base(jsonOptions)
             {
+                this.status = status;
+                this.error = error;
             }
 
             protected override Task<OneOf<TypedResource, LongRunningOperation, ErrorResponse>> HandleAsync(TypedResourceSpecification request, CancellationToken cancellationToken) =>
@@ -110,16 +163,19 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
                     Type = request.Type,
                     Identifiers = new TestIdentifiers { Name = "widget" },
                     Properties = request.Properties,
-                    Status = "Running",
-                    Error = new Error { Code = "Simulated", Message = "Simulated failure." },
+                    Status = this.status,
+                    Error = this.error,
                 });
         }
 
         private sealed class StubGetHandler : TypedResourceGetHandler<TestProperties, TestIdentifiers>
         {
-            public StubGetHandler(IOptions<JsonOptions> jsonOptions)
+            private readonly string status;
+
+            public StubGetHandler(IOptions<JsonOptions> jsonOptions, string status)
                 : base(jsonOptions)
             {
+                this.status = status;
             }
 
             protected override Task<OneOf<TypedResource?, ErrorResponse>> HandleAsync(TypedResourceReference request, CancellationToken cancellationToken) =>
@@ -128,15 +184,18 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
                     Type = request.Type,
                     Identifiers = new TestIdentifiers { Name = "widget" },
                     Properties = new TestProperties { Name = "widget" },
-                    Status = "Succeeded",
+                    Status = this.status,
                 });
         }
 
         private sealed class StubDeleteHandler : TypedResourceDeleteHandler<TestProperties, TestIdentifiers>
         {
-            public StubDeleteHandler(IOptions<JsonOptions> jsonOptions)
+            private readonly string status;
+
+            public StubDeleteHandler(IOptions<JsonOptions> jsonOptions, string status)
                 : base(jsonOptions)
             {
+                this.status = status;
             }
 
             protected override Task<OneOf<TypedResource?, LongRunningOperation, ErrorResponse>> HandleAsync(TypedResourceReference request, CancellationToken cancellationToken) =>
@@ -145,16 +204,18 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
                     Type = request.Type,
                     Identifiers = new TestIdentifiers { Name = "widget" },
                     Properties = new TestProperties { Name = "widget" },
-                    Status = "Deleting",
-                    Error = new Error { Code = "Simulated", Message = "Simulated failure." },
+                    Status = this.status,
                 });
         }
 
         private sealed class StubPreviewHandler : TypedResourcePreviewHandler<TestProperties, TestIdentifiers>
         {
-            public StubPreviewHandler(IOptions<JsonOptions> jsonOptions)
+            private readonly string status;
+
+            public StubPreviewHandler(IOptions<JsonOptions> jsonOptions, string status)
                 : base(jsonOptions)
             {
+                this.status = status;
             }
 
             protected override Task<OneOf<TypedResourcePreview, ErrorResponse>> HandleAsync(TypedResourcePreviewSpecification request, CancellationToken cancellationToken) =>
@@ -163,8 +224,28 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
                     Type = request.Type,
                     Identifiers = new TestIdentifiers { Name = "widget" },
                     Properties = request.Properties,
-                    Status = "Running",
+                    Status = this.status,
                 });
+        }
+
+        /// <summary>
+        /// Exposes the protected untyped-to-typed mapping helpers for direct testing.
+        /// </summary>
+        private sealed class MappingProbe : TypedResourceOperationHandler<TestProperties, TestIdentifiers, JsonObject?>
+        {
+            public MappingProbe(IOptions<JsonOptions> jsonOptions)
+                : base(jsonOptions)
+            {
+            }
+
+            public (string? Status, Error? Error) ConvertToTyped(Resource resource)
+            {
+                var typed = this.ToTypedResource(resource);
+
+                return (typed.Status, typed.Error);
+            }
+
+            public string? ConvertToTypedPreview(ResourcePreview preview) => this.ToTypedResourcePreview(preview).Status;
         }
     }
 }

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Properties/AssemblyInfo.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+[assembly: AssemblyTrait("Category", "Unit")]

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/TypedResourceOperationHandler.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/TypedResourceOperationHandler.cs
@@ -73,6 +73,7 @@ public abstract class TypedResourceOperationHandler<TProperties, TIdentifiers, T
         Properties = this.DeserializeProperties(preview.Properties),
         Config = this.DeserializeConfig(preview.Config),
         ConfigId = preview.ConfigId,
+        Status = preview.Status,
         Metadata = preview.Metadata,
     };
 
@@ -84,6 +85,7 @@ public abstract class TypedResourceOperationHandler<TProperties, TIdentifiers, T
         Properties = this.SerializeProperties(preview.Properties),
         Config = this.SerializeConfig(preview.Config),
         ConfigId = preview.ConfigId,
+        Status = preview.Status,
         Metadata = preview.Metadata,
     };
 
@@ -113,6 +115,8 @@ public abstract class TypedResourceOperationHandler<TProperties, TIdentifiers, T
         Properties = this.DeserializeProperties(resource.Properties),
         Config = this.DeserializeConfig(resource.Config),
         ConfigId = resource.ConfigId,
+        Status = resource.Status,
+        Error = resource.Error,
     };
 
     protected Resource? ToNullableResource(TypedResource? resource) => resource is null ? null : this.ToResource(resource);
@@ -125,6 +129,8 @@ public abstract class TypedResourceOperationHandler<TProperties, TIdentifiers, T
         Properties = this.SerializeProperties(resource.Properties),
         Config = this.SerializeConfig(resource.Config),
         ConfigId = resource.ConfigId,
+        Status = resource.Status,
+        Error = resource.Error,
     };
     
     private TProperties DeserializeProperties(JsonObject propertiesObject)


### PR DESCRIPTION
## Summary

`TypedResourceOperationHandler` dropped the `Resource.Status` / `Resource.Error` fields (and `ResourcePreview.Status`) when mapping between the strongly-typed handler models and the untyped V2 contract models.

This silently broke the **RELO** (resource-based long-running operation) flow for any handler built on the typed base classes: a non-terminal status (e.g. `"Running"`) or a terminal `"Failed"` + `error` set on the typed result never reached the untyped response. Because Get/Delete also funnel through `ToResource` (via `ToNullableResource`), polling never observed the status, so RELO appeared to complete synchronously.

LRO was unaffected, since `LongRunningOperation` is returned via passthrough rather than through these mappers.

## Changes

- `ToResource` (typed → untyped) and `ToTypedResource` (untyped → typed): copy `Status` and `Error`.
- `ToResourcePreview` and `ToTypedResourcePreview`: copy `Status` (`ResourcePreview` has no `Error` field).
- New project `Azure.Deployments.Extensibility.AspNetCore.Tests.Unit` with regression tests driving real typed handlers through the public interface and asserting `Status`/`Error` survive the round trip (create, get, delete, preview). These fail on the previous code and pass now.

## Testing

- New tests: 4/4 pass.
- Full solution builds clean (purely additive change).

## Rollback

Revert this commit. The change only adds field assignments in the model-mapping helpers, so reverting restores the prior behavior with no migration or state concerns.
