### PR TITLE
Updates for resource preview metadata.

### DIFF
--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
@@ -91,6 +91,7 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
             {
                 Type = "Test",
                 Properties = new JsonObject { ["name"] = "widget" },
+                Metadata = new ResourcePreviewSpecificationMetadata()
             };
 
             var result = await ((IResourcePreviewHandler)sut).HandleAsync(request, CancellationToken.None);

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/TypedResourceMappingTests.cs
@@ -7,6 +7,7 @@ using Azure.Deployments.Extensibility.Core.V2.Contracts;
 using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
 using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
 using FluentAssertions;
+using Json.Pointer;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -91,13 +92,18 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
             {
                 Type = "Test",
                 Properties = new JsonObject { ["name"] = "widget" },
-                Metadata = new ResourcePreviewSpecificationMetadata()
+                Metadata = new ResourcePreviewSpecificationMetadata
+                {
+                    Unevaluated = [JsonPointer.Parse("/properties/unevaluated")]
+                }
             };
 
             var result = await ((IResourcePreviewHandler)sut).HandleAsync(request, CancellationToken.None);
 
             result.IsT0.Should().BeTrue();
             result.AsT0!.Status.Should().Be("Running");
+            result.AsT0.Metadata.Should().NotBeNull();
+            result.AsT0.Metadata.Unevaluated.Should().BeEquivalentTo(request.Metadata.Unevaluated);
         }
 
         [Fact]
@@ -128,6 +134,7 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
                 Type = "Test",
                 Identifiers = new JsonObject { ["name"] = "widget" },
                 Properties = new JsonObject { ["name"] = "widget" },
+                Metadata = new ResourcePreviewMetadata(),
                 Status = "Running",
             };
 
@@ -225,6 +232,7 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers
                     Type = request.Type,
                     Identifiers = new TestIdentifiers { Name = "widget" },
                     Properties = request.Properties,
+                    Metadata = ResourcePreviewMetadata.NewBuilder().WithMetadataFromSpec(request.Metadata).Build(),
                     Status = this.status,
                 });
         }

--- a/src/Azure.Deployments.Extensibility.Core.Tests.Unit/V2/Contracts/Models/ResourcePreviewMetadataTests.cs
+++ b/src/Azure.Deployments.Extensibility.Core.Tests.Unit/V2/Contracts/Models/ResourcePreviewMetadataTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Json.Pointer;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.Core.Tests.Unit.V2.Contracts.Models
+{
+    public class ResourcePreviewMetadataTests
+    {
+        [Fact]
+        public void Build_WithNoProperties_ReturnsAllNull()
+        {
+            var metadata = ResourcePreviewMetadata.NewBuilder().Build();
+
+            metadata.ReadOnly.Should().BeNull();
+            metadata.Immutable.Should().BeNull();
+            metadata.Unknown.Should().BeNull();
+            metadata.Calculated.Should().BeNull();
+            metadata.Unevaluated.Should().BeNull();
+        }
+
+        [Fact]
+        public void Build_WithAllProperties_ReturnsExpectedObject()
+        {
+            var readOnly1 = JsonPointer.Parse("/a");
+            var readOnly2 = JsonPointer.Parse("/b");
+            var readOnly3 = JsonPointer.Parse("/c");
+            var readOnly4 = JsonPointer.Parse("/d");
+            var readOnlyDupe = JsonPointer.Parse("/c");
+
+            var immutable1 = JsonPointer.Parse("/d");
+            var immutable2 = JsonPointer.Parse("/e");
+            var immutable3 = JsonPointer.Parse("/f");
+            var immutable4 = JsonPointer.Parse("/g");
+            var immutableDupe = JsonPointer.Parse("/d");
+
+            var unknown1 = JsonPointer.Parse("/a/b");
+            var unknown2 = JsonPointer.Parse("/a/c");
+            var unknown3 = JsonPointer.Parse("/b/c");
+            var unknown4 = JsonPointer.Parse("/b/d");
+            var unknownDupe = JsonPointer.Parse("/a/c");
+
+            var calculated1 = JsonPointer.Parse("/h");
+            var calculated2 = JsonPointer.Parse("/i");
+            var calculated3 = JsonPointer.Parse("/j");
+            var calculated4 = JsonPointer.Parse("/k");
+            var calculatedDupe = JsonPointer.Parse("/h");
+
+            var unevaluated1 = JsonPointer.Parse("/l");
+            var unevaluated2 = JsonPointer.Parse("/m");
+            var unevaluated3 = JsonPointer.Parse("/n");
+            var unevaluated4 = JsonPointer.Parse("/o");
+            var unevaluatedDupe = JsonPointer.Parse("/n");
+
+            IEnumerable<JsonPointer>? nullEnumerable = null;
+
+            var metadata = ResourcePreviewMetadata.NewBuilder()
+                .WithReadOnly(readOnly1)
+                .WithReadOnly(readOnly1, readOnly2)
+                .WithReadOnly(new List<JsonPointer> { readOnly3, readOnly4, readOnlyDupe })
+                .WithReadOnly(nullEnumerable)
+                .WithImmutable(immutable1)
+                .WithImmutable(immutable2, immutable3)
+                .WithImmutable(new HashSet<JsonPointer> { immutable4, immutableDupe })
+                .WithImmutable(nullEnumerable)
+                .WithUnknown(unknown1, unknown2)
+                .WithUnknown(unknown3)
+                .WithUnknown(new List<JsonPointer> { unknown4, unknownDupe })
+                .WithUnknown(nullEnumerable)
+                .WithCalculated(calculated1, calculated2)
+                .WithCalculated(calculatedDupe)
+                .WithCalculated(new[] { calculated3, calculated4 })
+                .WithCalculated(nullEnumerable)
+                .WithUnevaluated(unevaluated1)
+                .WithUnevaluated(unevaluated2, unevaluated3)
+                .WithUnevaluated(new List<JsonPointer> { unevaluated4, unevaluatedDupe })
+                .WithUnevaluated(nullEnumerable)
+                .Build();
+
+            metadata.ReadOnly.Should().NotBeNull();
+            metadata.ReadOnly!.Value.Should().BeEquivalentTo([readOnly1, readOnly2, readOnly3, readOnly4]);
+
+            metadata.Immutable.Should().NotBeNull();
+            metadata.Immutable!.Value.Should().BeEquivalentTo([immutable1, immutable2, immutable3, immutable4]);
+
+            metadata.Unknown.Should().NotBeNull();
+            metadata.Unknown!.Value.Should().BeEquivalentTo([unknown1, unknown2, unknown3, unknown4]);
+
+            metadata.Calculated.Should().NotBeNull();
+            metadata.Calculated!.Value.Should().BeEquivalentTo([calculated1, calculated2, calculated3, calculated4]);
+
+            metadata.Unevaluated.Should().NotBeNull();
+            metadata.Unevaluated!.Value.Should().BeEquivalentTo([unevaluated1, unevaluated2, unevaluated3, unevaluated4]);
+        }
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreview.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreview.cs
@@ -33,30 +33,30 @@ public record ResourcePreview<TProperties, TIdentifiers, TConfig>
     /// <param name="type">The type of the resource.</param>
     /// <param name="identifiers">The identifiers that uniquely identify the resource.</param>
     /// <param name="properties">The properties of the resource.</param>
+    /// <param name="metadata">The metadata describing property classifications in the preview.</param>
     /// <param name="apiVersion">The API version of the resource.</param>
     /// <param name="status">The status of the resource.</param>
     /// <param name="config">The configuration of the resource, with secret properties removed.</param>
     /// <param name="configId">A value that uniquely identifies the deployment control plane.</param>
-    /// <param name="metadata">The metadata describing property classifications in the preview.</param>
     [SetsRequiredMembers]
     public ResourcePreview(
         string type,
         TIdentifiers identifiers,
         TProperties properties,
+        ResourcePreviewMetadata metadata,
         string? apiVersion = null,
         string? status = null,
         TConfig? config = default,
-        string? configId = null,
-        ResourcePreviewMetadata? metadata = null)
+        string? configId = null)
     {
         this.Type = type;
         this.Identifiers = identifiers;
         this.Properties = properties;
+        this.Metadata = metadata;
         this.ApiVersion = apiVersion;
         this.Status = status;
         this.Config = config;
         this.ConfigId = configId;
-        this.Metadata = metadata;
     }
 
     /// <summary>
@@ -97,9 +97,10 @@ public record ResourcePreview<TProperties, TIdentifiers, TConfig>
     public string? ConfigId { get; init; }
 
     /// <summary>
-    /// The metadata describing which properties in the preview are read-only, immutable, calculated, or unevaluated.
+    /// The metadata describing which properties in the preview are read-only, immutable, calculated, or unevaluated. Minimally, the extension
+    /// should echo back what it received from the deployment engine.
     /// </summary>
-    public ResourcePreviewMetadata? Metadata { get; init; }
+    public required ResourcePreviewMetadata Metadata { get; init; }
 }
 
 /// <inheritdoc cref="ResourcePreview{TProperties, TIdentifiers, TConfig}"/>

--- a/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewMetadata.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewMetadata.cs
@@ -181,11 +181,11 @@ public record ResourcePreviewMetadata
         public ResourcePreviewMetadata Build() =>
             new()
             {
-                Calculated = [..this.Calculated.Distinct()],
-                Immutable = [..this.Immutable.Distinct()],
-                ReadOnly = [..this.ReadOnly.Distinct()],
-                Unevaluated = [..this.Unevaluated.Distinct()],
-                Unknown = [..this.Unknown.Distinct()]
+                Calculated = this.Calculated.Distinct().ToImmutableArray() is { Length: > 0 } calculated ? calculated : null,
+                Immutable = this.Immutable.Distinct().ToImmutableArray() is { Length: > 0 } immutable ? immutable : null,
+                ReadOnly = this.ReadOnly.Distinct().ToImmutableArray() is { Length: > 0 } readOnly ? readOnly : null,
+                Unevaluated = this.Unevaluated.Distinct().ToImmutableArray() is { Length: > 0 } unevaluated ? unevaluated : null,
+                Unknown = this.Unknown.Distinct().ToImmutableArray() is { Length: > 0 } unknown ? unknown : null
             };
     }
 }

--- a/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewMetadata.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewMetadata.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Json.Pointer;
 using System.Collections.Immutable;
+using Json.Pointer;
 
 namespace Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
 
@@ -16,6 +16,9 @@ namespace Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
 /// </remarks>
 public record ResourcePreviewMetadata
 {
+    /// <summary>Creates a new ResourcePreviewMetadata builder.</summary>
+    public static Builder NewBuilder() => new();
+    
     /// <summary>
     /// JSON Pointers to properties managed entirely by the service. The user cannot set these.
     /// </summary>
@@ -44,4 +47,145 @@ public record ResourcePreviewMetadata
     /// specific category (readOnly, immutable, calculated, unknown) applies.
     /// </summary>
     public ImmutableArray<JsonPointer>? Unevaluated { get; init; }
+
+    public class Builder
+    {
+        private IEnumerable<JsonPointer> Calculated { get; set; } = [];
+        private IEnumerable<JsonPointer> Immutable { get; set; } = [];
+        private IEnumerable<JsonPointer> ReadOnly { get; set; } = [];
+        private IEnumerable<JsonPointer> Unevaluated { get; set; } = [];
+        private IEnumerable<JsonPointer> Unknown { get; set; } = [];
+
+        public Builder WithMetadataFromSpec(ResourcePreviewSpecificationMetadata metadata) => this.WithUnevaluated(metadata.Unevaluated);
+
+        public Builder WithCalculated(JsonPointer pointer)
+        {
+            this.Calculated = this.Calculated.Append(pointer);
+
+            return this;
+        }
+
+        public Builder WithCalculated(params JsonPointer[] pointers)
+        {
+            this.Calculated = this.Calculated.Concat(pointers);
+
+            return this;
+        }
+
+        public Builder WithCalculated(IEnumerable<JsonPointer>? pointers)
+        {
+            if (pointers is not null)
+            {
+                this.Calculated = this.Calculated.Concat(pointers);
+            }
+
+            return this;
+        }
+
+        public Builder WithImmutable(JsonPointer pointer)
+        {
+            this.Immutable = this.Immutable.Append(pointer);
+
+            return this;
+        }
+
+        public Builder WithImmutable(params JsonPointer[] pointers)
+        {
+            this.Immutable = this.Immutable.Concat(pointers);
+
+            return this;
+        }
+
+        public Builder WithImmutable(IEnumerable<JsonPointer>? pointers)
+        {
+            if (pointers is not null)
+            {
+                this.Immutable = this.Immutable.Concat(pointers);
+            }
+
+            return this;
+        }
+
+        public Builder WithReadOnly(JsonPointer pointer)
+        {
+            this.ReadOnly = this.ReadOnly.Append(pointer);
+
+            return this;
+        }
+
+        public Builder WithReadOnly(params JsonPointer[] pointers)
+        {
+            this.ReadOnly = this.ReadOnly.Concat(pointers);
+
+            return this;
+        }
+
+        public Builder WithReadOnly(IEnumerable<JsonPointer>? pointers)
+        {
+            if (pointers is not null)
+            {
+                this.ReadOnly = this.ReadOnly.Concat(pointers);
+            }
+
+            return this;
+        }
+
+        public Builder WithUnevaluated(JsonPointer pointer)
+        {
+            this.Unevaluated = this.Unevaluated.Append(pointer);
+
+            return this;
+        }
+
+        public Builder WithUnevaluated(params JsonPointer[] pointers)
+        {
+            this.Unevaluated = this.Unevaluated.Concat(pointers);
+
+            return this;
+        }
+
+        public Builder WithUnevaluated(IEnumerable<JsonPointer>? pointers)
+        {
+            if (pointers is not null)
+            {
+                this.Unevaluated = this.Unevaluated.Concat(pointers);
+            }
+
+            return this;
+        }
+
+        public Builder WithUnknown(JsonPointer pointer)
+        {
+            this.Unknown = this.Unknown.Append(pointer);
+
+            return this;
+        }
+
+        public Builder WithUnknown(params JsonPointer[] pointers)
+        {
+            this.Unknown = this.Unknown.Concat(pointers);
+
+            return this;
+        }
+
+        public Builder WithUnknown(IEnumerable<JsonPointer>? pointers)
+        {
+            if (pointers is not null)
+            {
+                this.Unknown = this.Unknown.Concat(pointers);
+            }
+
+            return this;
+        }
+
+        public ResourcePreviewMetadata Build() =>
+            new()
+            {
+                Calculated = [..this.Calculated.Distinct()],
+                Immutable = [..this.Immutable.Distinct()],
+                ReadOnly = [..this.ReadOnly.Distinct()],
+                Unevaluated = [..this.Unevaluated.Distinct()],
+                Unknown = [..this.Unknown.Distinct()]
+            };
+    }
 }

--- a/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewSpecification.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewSpecification.cs
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 namespace Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
 
 /// <summary>
 /// Represents the specification for a resource preview request.
-/// Extends <see cref="ResourceSpecification{TProperties, TConfig}"/> with optional preview metadata
-/// indicating which properties contain unevaluated ARM template expressions.
+/// Extends <see cref="ResourceSpecification{TProperties, TConfig}"/> with preview metadata indicating which properties contain unevaluated
+/// ARM template expressions.
 /// </summary>
 /// <typeparam name="TProperties">The type representing the resource properties.</typeparam>
 /// <typeparam name="TConfig">The type representing the extension configuration.</typeparam>
@@ -17,10 +18,26 @@ namespace Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
 /// </remarks>
 public record ResourcePreviewSpecification<TProperties, TConfig> : ResourceSpecification<TProperties, TConfig>
 {
+    public ResourcePreviewSpecification()
+    {
+    }
+
+    [SetsRequiredMembers]
+    public ResourcePreviewSpecification(
+        string type,
+        TProperties properties,
+        ResourcePreviewSpecificationMetadata metadata,
+        string? apiVersion = null,
+        TConfig? config = default,
+        string? configId = null) : base(type, properties, apiVersion, config, configId)
+    {
+        this.Metadata = metadata;
+    }
+    
     /// <summary>
-    /// Optional metadata for the preview specification, such as properties that could not be evaluated.
+    /// Metadata for the preview specification, such as properties that could not be evaluated.
     /// </summary>
-    public ResourcePreviewSpecificationMetadata? Metadata { get; init; }
+    public required ResourcePreviewSpecificationMetadata Metadata { get; init; }
 }
 
 /// <inheritdoc cref="ResourcePreviewSpecification{TProperties, TConfig}"/>

--- a/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewSpecificationMetadata.cs
+++ b/src/Azure.Deployments.Extensibility.Core/V2/Contracts/Models/ResourcePreviewSpecificationMetadata.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Json.Pointer;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using Json.Pointer;
 
 namespace Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
 
@@ -16,8 +16,10 @@ public record ResourcePreviewSpecificationMetadata
     /// <summary>
     /// Initializes a new instance of the <see cref="ResourcePreviewSpecificationMetadata"/> record.
     /// </summary>
+    [SetsRequiredMembers]
     public ResourcePreviewSpecificationMetadata()
     {
+        this.Unevaluated = [];
     }
 
     /// <summary>


### PR DESCRIPTION
- Make `ResourcePreviewSpecificationMetadata` non-null on the preview request model. The Deployments engine always sends this.
- Make `ResourcePreviewMetadata` required on the response because extensions must minimally echo it back.
- Add a convenience builder for `ResourcePreviewMetadata` to simplify its construction through a preview pipeline.