### PR TITLE
Add version-free AspNetCore extension runtime

### DIFF
--- a/SDK-Restructuring-Plan.md
+++ b/SDK-Restructuring-Plan.md
@@ -1,0 +1,277 @@
+# Bicep Extensibility SDK Restructuring - Follow-up Plan
+
+> Status: follow-up work after the additive AspNetCore foundation PR. This document intentionally
+> omits work implemented by that PR and describes only the remaining migrations, removals, and
+> release gates.
+
+## Target state
+
+- `Azure.Deployments.Extensibility.Core`, `Azure.Deployments.Extensibility.AspNetCore`, and
+  `Azure.Deployments.Extensibility.Hosting.Managed` expose no version-range API and have no direct or
+  transitive `Semver` dependency.
+- `Azure.Deployments.Extensibility.Hosting.FirstParty` is the only package that owns version-range
+  parsing, overlap validation, and multi-version selection.
+- AspNetCore exports no application wrapper, concrete extension/version/resource builder, range-aware
+  registry, or legacy dispatcher.
+- Managed and FirstParty hosts compose with the standard `WebApplicationBuilder` and `WebApplication`.
+- MS Graph, Contoso, and the in-repo sample no longer reference the legacy AspNetCore hosting path.
+- No Managed package is published until its AspNetCore dependency is clean.
+
+## Dependency order
+
+```mermaid
+flowchart LR
+    Foundation[Additive AspNetCore foundation] --> CoreCleanup[Core Semver cleanup]
+    Foundation --> FirstParty[Hosting.FirstParty implementation]
+    Foundation --> Managed[Hosting.Managed implementation]
+    FirstParty --> Graph[MS Graph migration]
+    FirstParty --> Contoso[Contoso migration]
+    FirstParty --> FirstPartySurface[Move 1P-only AspNetCore surface]
+    Managed --> Sample[Managed sample and docs migration]
+    Graph --> LegacyRemoval[Legacy AspNetCore removal]
+    Contoso --> LegacyRemoval
+    FirstPartySurface --> LegacyRemoval
+    Sample --> LegacyRemoval
+    LegacyRemoval --> ReleaseGate[API and package release gate]
+    CoreCleanup --> ReleaseGate
+    Managed --> ReleaseGate
+```
+
+Core cleanup and the two hosting SDK implementations can proceed in parallel. Legacy removal cannot
+start until both external 1P consumers and all in-repo call sites have migrated.
+
+## PR 1: Remove Core's stale Semver dependency
+
+**Repository:** `Azure/bicep-extensibility`
+
+Remove:
+
+- The unused `using Semver;` from
+  `src/Azure.Deployments.Extensibility.Core/V2/Contracts/Handlers/IHandler.cs`.
+- The `Semver` package reference from
+  `src/Azure.Deployments.Extensibility.Core/Azure.Deployments.Extensibility.Core.csproj`.
+
+**Gates:**
+
+- Build and test Core.
+- Pack Core and verify that its package dependency closure contains no `Semver` reference.
+
+## PR 2: Implement Hosting.FirstParty
+
+**Repository:** `Mgmt-Governance-Blueprint`
+
+Build the FirstParty host on the shared AspNetCore registration and resolver contracts:
+
+- Add `IBicepFirstPartyExtensionBuilder` with global behavior registration and
+  `AddVersion(string, Action<IBicepExtensionBuilder>)`.
+- Create one `BicepExtensionRegistration` per configured range.
+- Keep `SemVersionRange`, range parsing, and the range table internal to Hosting.FirstParty.
+- Implement `IBicepExtensionResolver` by parsing the exact route version and selecting one registration.
+- Reject duplicate or overlapping ranges during startup. Do not define precedence between overlaps.
+- Add aggregate and granular standard-host integration for existing 1P applications.
+- Register and map no default health endpoint.
+- Provide FirstParty-owned replacements for tenant identity enrichment before those surfaces are
+  removed from AspNetCore.
+
+**Gates:**
+
+- Test exact boundaries, prereleases, malformed versions, unmatched versions, duplicate ranges, and
+  overlapping ranges.
+- Test behavior ordering and unsupported-version wrapping by global behaviors.
+- Test both bare routes and a host-owned `MapGroup(prefix)` integration.
+- Verify that no health services or `/ping` endpoint are added by default.
+
+## PR 3: Migrate MS Graph
+
+**Repository:** the MS Graph extension repository
+
+- Replace `ExtensionApplication` with the standard ASP.NET Core host.
+- Move all version registrations to Hosting.FirstParty.
+- Preserve global and per-version behavior ordering, default handlers, request-header access, and
+  existing route behavior.
+- Remove all references to `ExtensionApplication`, `ExtensionVersionBuilder`, `ResourceTypeBuilder`,
+  `HandlerRegistry`, and `HandlerBehaviorRegistry`.
+
+**Gates:**
+
+- Build and run the Graph extension against the additive AspNetCore package and Hosting.FirstParty.
+- Exercise every supported version plus malformed and unsupported versions.
+- Confirm that v2 handlers can still resolve `IHttpContextAccessor`.
+
+## PR 4: Migrate Contoso
+
+**Repository:** `Mgmt-Governance-Blueprint`
+
+- Replace `ExtensionApplication` with the standard ASP.NET Core host.
+- Use the granular FirstParty and shared AspNetCore helpers so the application retains control over
+  MISE/authentication ordering, custom exception handling, and route groups.
+- Preserve the existing endpoint prefix and host-owned health behavior.
+- Remove all references to the legacy AspNetCore hosting and registry types.
+
+**Gates:**
+
+- Run Contoso unit and integration tests.
+- Verify authentication/authorization/MISE and extension middleware order.
+- Exercise contract endpoints beneath the existing route prefix.
+- Confirm that Hosting.FirstParty does not add another health endpoint.
+
+## PR 5: Implement Hosting.Managed
+
+**Repository:** `Azure/bicep-extensibility`
+
+- Add `AddBicepExtension(Action<IBicepExtensionBuilder>)` over one immutable registration.
+- Add an exact-version `IBicepExtensionResolver`; compare the incoming route version ordinally and do
+  not parse it as a range.
+- Read extension identity from assembly metadata emitted from the extension project's MSBuild
+  properties.
+- Add the Managed aggregate that installs shared middleware, bare contract routes, health services,
+  and fixed `GET /ping` on the real `WebApplication`.
+- Fail clearly when identity metadata, the resolver, or required application integration is missing or
+  duplicated.
+
+Keep this package unpublished until PR 8 completes.
+
+**Gates:**
+
+- Test exact match and mismatch without any range parsing.
+- Test required bare routes and `/ping`, including duplicate aggregate calls.
+- Verify that arbitrary user services, middleware, and endpoints remain available.
+- Pack a scratch consumer and verify that it uses only public SDK APIs.
+
+## PR 6: Migrate the sample and authored documentation
+
+**Repository:** `Azure/bicep-extensibility`
+
+The current Magic Eight Ball sample serves v1 and v2 from one `ExtensionApplication`. A Managed process
+owns one exact version, so choose one of these forms before removing the legacy path:
+
+1. Prefer one Managed sample version in this repository and move the multi-version example to the
+   Hosting.FirstParty repository.
+2. If both sample versions must remain here, split them into two Managed executables.
+
+Update these authored surfaces to use the standard host and the new hosting APIs:
+
+- `sample/MagicEightBallExtension/Program.cs`
+- `sample/MagicEightBallExtension/README.md`
+- `src/Azure.Deployments.Extensibility.AspNetCore/README.md`
+- `docs/index.md`
+- `docs/sdks/index.md`
+- `docs/sdks/aspnetcore.md`
+- `docs/tutorials/getting-started.md`
+- `docs/tutorials/behaviors.md`
+- `docs/tutorials/typed-handlers.md`
+- Legacy symbol references in `spec/http.tsp`
+
+Retain the generic Scalar explorer as shared tooling: expose its `WebApplication` mapping helper for
+standard-host use and call it directly from the sample. `OpenApiExamplesBuilder` remains shared; it does
+not depend on version ranges or tenant identity.
+
+Do not hand-edit generated DocFX output under `docs/_site` or generated API metadata.
+
+**Gates:**
+
+- Build and run every retained sample executable.
+- Exercise supported, unsupported, and malformed versions, behavior ordering, and LRO dispatch.
+- Build TypeSpec and DocFX output using the repository workflows.
+- Search authored docs and sample code for the legacy symbols listed in PR 8.
+
+## PR 7: Move FirstParty-only AspNetCore surfaces
+
+**Repositories:** `Mgmt-Governance-Blueprint`, then `Azure/bicep-extensibility`
+
+Remove the shared package's ownership of 1P tenant identity only after Hosting.FirstParty has equivalent
+functionality and both 1P consumers use it:
+
+- Remove `HomeTenantId` and `ClientTenantId` from
+  `src/Azure.Deployments.Extensibility.AspNetCore/Constants/RequestHeaderNames.cs`.
+- Remove `GetHomeTenantId()` and `GetClientTenantId()` from
+  `src/Azure.Deployments.Extensibility.AspNetCore/HttpContextExtensions.cs`.
+- Remove tenant fields from the logging scope in
+  `src/Azure.Deployments.Extensibility.AspNetCore/Middlewares/RequestCorrelationMiddleware.cs`.
+- Remove tenant headers from `spec/http.tsp` and regenerate the shared OpenAPI contract.
+- Remove tenant header examples from
+  `src/Azure.Deployments.Extensibility.AspNetCore/Extensions/ScalarExtensions.cs` while retaining its
+  generic request, correlation, language, trace, and exact-version examples.
+
+Keep the shared client request ID, correlation request ID, response request ID, and correlation
+middleware. Those headers are part of the shared HTTP contract. Keep the generic Scalar explorer and
+`OpenApiExamplesBuilder` in AspNetCore.
+
+**Gates:**
+
+- Verify Graph and Contoso tenant logging from Hosting.FirstParty.
+- Verify shared correlation behavior without tenant headers.
+- Confirm that the shared TypeSpec, OpenAPI document, middleware, accessors, and Scalar examples no
+  longer reference tenant identity.
+
+## PR 8: Remove the legacy range-aware AspNetCore graph
+
+**Repository:** `Azure/bicep-extensibility`
+
+Treat this as one coordinated breaking PR. Delete in reverse dependency order so intermediate commits
+remain understandable:
+
+1. Remove
+  `src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/ExtensionApplicationTests.cs` after the
+  last legacy consumer is gone.
+2. Delete `src/Azure.Deployments.Extensibility.AspNetCore/ExtensionApplication.cs`.
+3. Delete the legacy host helpers:
+  `src/Azure.Deployments.Extensibility.AspNetCore/Extensions/WebApplicationExtensions.cs` and
+  `src/Azure.Deployments.Extensibility.AspNetCore/Extensions/WebApplicationBuilderExtensions.cs`.
+4. Delete the concrete range-aware builders:
+  `src/Azure.Deployments.Extensibility.AspNetCore/Builders/ExtensionVersionBuilder.cs` and
+  `src/Azure.Deployments.Extensibility.AspNetCore/Builders/ResourceTypeBuilder.cs`.
+5. Delete the wrapper-only
+  `src/Azure.Deployments.Extensibility.AspNetCore/Builders/ScalarApiExplorerBuilder.cs`; retain the
+  standard-host Scalar mapping helper and `OpenApiExamplesBuilder`.
+6. Delete the legacy HTTP adapter:
+  `src/Azure.Deployments.Extensibility.AspNetCore/Handlers/HandlerDispatcher.cs`.
+7. Delete the range-aware registries:
+  `src/Azure.Deployments.Extensibility.AspNetCore/Handlers/HandlerRegistry.cs` and
+  `src/Azure.Deployments.Extensibility.AspNetCore/Behaviors/HandlerBehaviorRegistry.cs`.
+8. Delete legacy-only fallback and pipeline types:
+  `src/Azure.Deployments.Extensibility.AspNetCore/Handlers/UnknownExtensionVersionHandler.cs`,
+  `src/Azure.Deployments.Extensibility.AspNetCore/Handlers/UnknownResourceTypeHandler.cs`, and
+  `src/Azure.Deployments.Extensibility.AspNetCore/Behaviors/ErrorResponseExceptionHandlingBehavior.cs`.
+9. Remove the `Semver` package reference from
+  `src/Azure.Deployments.Extensibility.AspNetCore/Azure.Deployments.Extensibility.AspNetCore.csproj`.
+
+Do not remove the new `BicepExtensionRegistration`, `IBicepExtensionResolver`, internal
+`HandlerInvoker`, new HTTP dispatcher, public shared DI/middleware helpers, or
+`IEndpointRouteBuilder` endpoint helpers.
+
+**Required preconditions:**
+
+- MS Graph and Contoso are deployed on Hosting.FirstParty.
+- The Magic Eight Ball sample and all authored docs use a new hosting SDK.
+- Hosting.FirstParty owns all required range and 1P identity behavior.
+- Hosting.Managed passes its package-consumer tests but has not been published.
+
+**Gates:**
+
+- Build the full solution and run every unit-test project.
+- Pack Core and AspNetCore.
+- Build MS Graph and Contoso against the packed clean AspNetCore package.
+- Build a public-only FirstParty consumer and a public-only Managed consumer.
+- Verify that Core and AspNetCore source, exported APIs, assembly references, and recursive NuGet
+  dependencies contain none of:
+  `Semver`, `SemVersionRange`, `ExtensionApplication`, `AddExtensionVersion`,
+  `ExtensionVersionBuilder`, `ResourceTypeBuilder`, `HandlerRegistry`, or
+  `HandlerBehaviorRegistry`.
+
+## PR 9: API gate and release
+
+**Repositories:** `Azure/bicep-extensibility` and `Mgmt-Governance-Blueprint`
+
+- Add or update the public API baseline/ApiCompat checks for the clean packages.
+- Publish clean Core and AspNetCore packages first.
+- Update Hosting.FirstParty to the released clean packages and rerun Graph and Contoso validation.
+- Publish Hosting.Managed only after that dependency update is complete.
+- Verify the released Managed dependency graph contains no transitional AspNetCore package or Semver
+  assembly.
+
+## Later work
+
+- Add the separate TypeGeneration SDK and extension-bundle workflow.
+- Complete broader public documentation after the clean hosting packages are available.
+- Remove any temporary compatibility notes or package pins introduced during the coordinated migration.

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.29" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/ExtensionApplicationTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/ExtensionApplicationTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit;
+
+public class ExtensionApplicationTests
+{
+    [Fact]
+    public async Task Build_WithLegacyRegistration_DoesNotRequireNewResolver()
+    {
+        var sut = ExtensionApplication.Create([]);
+        sut.Builder.Environment.EnvironmentName = Environments.Development;
+        sut.AddExtensionVersion("1.*.*", version => version.AddHandler<LegacyGetHandler>());
+
+        await using var app = sut.Build();
+
+        app.Should().NotBeNull();
+    }
+
+    private sealed class LegacyGetHandler : IResourceGetHandler
+    {
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, ErrorResponse>>((Resource?)null);
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/BicepExtensionEndpointTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/BicepExtensionEndpointTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Extensions;
+using Azure.Deployments.Extensibility.AspNetCore.Exceptions;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers;
+
+public class BicepExtensionEndpointTests
+{
+    [Fact]
+    public void MapEndpoints_WithoutResolver_Throws()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddBicepExtensionHandlerRuntime();
+        using var app = builder.Build();
+
+        var action = () => app.MapBicepExtensionEndpoints();
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void MapEndpoints_WithMultipleResolvers_Throws()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddBicepExtensionHandlerRuntime();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<EndpointGetHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        using var app = builder.Build();
+
+        var action = () => app.MapBicepExtensionEndpoints();
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task MapEndpoints_UnderRouteGroup_DispatchesRequest()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .ForResourceType("Widget", resourceType => resourceType.AddHandler<EndpointGetHandler>()));
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.UseBicepExtensionMiddlewares();
+        app.MapGroup("/extension/apis").MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Add("x-ms-client-request-id", "00000000-0000-0000-0000-000000000001");
+        client.DefaultRequestHeaders.Add("x-ms-correlation-request-id", "00000000-0000-0000-0000-000000000002");
+
+        var response = await client.PostAsJsonAsync(
+            "/extension/apis/1.0.0/resource/get",
+            new ResourceReference
+            {
+                Type = "Widget",
+                Identifiers = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resource = await response.Content.ReadFromJsonAsync<Resource>();
+        resource.Should().NotBeNull();
+        resource!.Type.Should().Be("Widget");
+    }
+
+    [Fact]
+    public async Task MapEndpoints_WithoutLroHandler_ReturnsProtocolError()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<EndpointGetHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/longRunningOperation/get",
+            new JsonObject { ["operationId"] = "example" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error.Should().NotBeNull();
+        error!.Error.Code.Should().Be("UnsupportedOperation");
+    }
+
+    [Fact]
+    public async Task MapEndpoints_WithHttpErrorResponse_PreservesStatusCode()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<ThrowingGetHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/resource/get",
+            new ResourceReference
+            {
+                Type = "Widget",
+                Identifiers = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error.Should().NotBeNull();
+        error!.Error.Code.Should().Be("Conflict");
+    }
+
+    private sealed class StubResolver : IBicepExtensionResolver
+    {
+        private readonly BicepExtensionRegistration registration;
+
+        public StubResolver(BicepExtensionRegistration registration)
+        {
+            this.registration = registration;
+        }
+
+        public BicepExtensionRegistration? Resolve(string extensionVersion) => this.registration;
+    }
+
+    private sealed class EndpointGetHandler : IResourceGetHandler
+    {
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, ErrorResponse>>(new Resource
+            {
+                Type = request.Type,
+                Identifiers = request.Identifiers,
+                Properties = new JsonObject { ["name"] = "example" },
+            });
+    }
+
+    private sealed class ThrowingGetHandler : IResourceGetHandler
+    {
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            throw new HttpErrorResponseException((int)HttpStatusCode.Conflict, "Conflict", "Expected conflict.");
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/BicepExtensionEndpointTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/BicepExtensionEndpointTests.cs
@@ -131,6 +131,115 @@ public class BicepExtensionEndpointTests
         error!.Error.Code.Should().Be("Conflict");
     }
 
+    [Fact]
+    public async Task MapEndpoints_WithCreateOrUpdateLro_ReturnsAccepted()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<CreateOrUpdateLroHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/resource/createOrUpdate",
+            new ResourceSpecification
+            {
+                Type = "Widget",
+                Properties = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var operation = await response.Content.ReadFromJsonAsync<LongRunningOperation>();
+        operation.Should().NotBeNull();
+        operation!.Status.Should().Be("Running");
+    }
+
+    [Fact]
+    public async Task MapEndpoints_WithDeleteLro_ReturnsAccepted()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<DeleteLroHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/resource/delete",
+            new ResourceReference
+            {
+                Type = "Widget",
+                Identifiers = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var operation = await response.Content.ReadFromJsonAsync<LongRunningOperation>();
+        operation.Should().NotBeNull();
+        operation!.Status.Should().Be("Running");
+    }
+
+    [Fact]
+    public async Task MapEndpoints_WithNullDeleteResult_ReturnsNoContent()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<NullDeleteHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/resource/delete",
+            new ResourceReference
+            {
+                Type = "Widget",
+                Identifiers = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task MapEndpoints_WithNullGetResult_ReturnsNotFound()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddBicepExtensionServices();
+        var registration = BicepExtensionRegistration.Create(builder.Services, extension => extension
+            .AddHandler<NullGetHandler>());
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        await using var app = builder.Build();
+        app.MapBicepExtensionEndpoints();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/resource/get",
+            new ResourceReference
+            {
+                Type = "Widget",
+                Identifiers = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        error.Should().NotBeNull();
+        error!.Error.Code.Should().Be("ResourceNotFound");
+    }
+
     private sealed class StubResolver : IBicepExtensionResolver
     {
         private readonly BicepExtensionRegistration registration;
@@ -162,5 +271,39 @@ public class BicepExtensionEndpointTests
             ResourceReference request,
             CancellationToken cancellationToken) =>
             throw new HttpErrorResponseException((int)HttpStatusCode.Conflict, "Conflict", "Expected conflict.");
+    }
+
+    private sealed class CreateOrUpdateLroHandler : IResourceCreateOrUpdateHandler
+    {
+        public Task<OneOf<Resource, LongRunningOperation, ErrorResponse>> HandleAsync(
+            ResourceSpecification request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource, LongRunningOperation, ErrorResponse>>(
+                new LongRunningOperation("Running", operationHandle: new JsonObject { ["id"] = "example" }));
+    }
+
+    private sealed class DeleteLroHandler : IResourceDeleteHandler
+    {
+        public Task<OneOf<Resource?, LongRunningOperation, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, LongRunningOperation, ErrorResponse>>(
+                new LongRunningOperation("Running", operationHandle: new JsonObject { ["id"] = "example" }));
+    }
+
+    private sealed class NullDeleteHandler : IResourceDeleteHandler
+    {
+        public Task<OneOf<Resource?, LongRunningOperation, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, LongRunningOperation, ErrorResponse>>((Resource?)null);
+    }
+
+    private sealed class NullGetHandler : IResourceGetHandler
+    {
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, ErrorResponse>>((Resource?)null);
     }
 }

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/BicepExtensionRegistrationTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/BicepExtensionRegistrationTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers;
+
+public class BicepExtensionRegistrationTests
+{
+    [Fact]
+    public void Create_WithNoHandlers_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var action = () => BicepExtensionRegistration.Create(services, _ => { });
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_WithDuplicateOperation_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var action = () => BicepExtensionRegistration.Create(services, extension => extension
+            .AddHandler<StubGetHandler>()
+            .AddHandler<SecondGetHandler>());
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_WithResourceScopedLroHandler_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var action = () => BicepExtensionRegistration.Create(services, extension => extension
+            .ForResourceType("Widget", resourceType => resourceType.AddHandler<StubLroHandler>()));
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Create_WithUnsupportedBehaviorShape_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var action = () => BicepExtensionRegistration.Create(services, extension => extension
+            .AddHandler<StubGetHandler>()
+            .AddHandlerBehavior<UnsupportedBehavior>());
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ResolveHandler_WithCaseInsensitiveResourceType_ReturnsHandler()
+    {
+        var services = new ServiceCollection();
+        var registration = BicepExtensionRegistration.Create(services, extension => extension
+            .ForResourceType("Widget", resourceType => resourceType.AddHandler<StubGetHandler>()));
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var handler = registration.ResolveHandler<IResourceGetHandler>("widget", serviceProvider);
+
+        handler.Should().BeOfType<StubGetHandler>();
+    }
+
+    [Fact]
+    public void ResolveHandler_WithSameTypeFactories_UsesIndependentRegistrations()
+    {
+        var services = new ServiceCollection();
+        var registration = BicepExtensionRegistration.Create(services, extension => extension
+            .ForResourceType("First", resourceType => resourceType.AddHandler(_ => new ConfiguredGetHandler("first")))
+            .ForResourceType("Second", resourceType => resourceType.AddHandler(_ => new ConfiguredGetHandler("second"))));
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = serviceProvider.CreateScope();
+
+        var first = registration.ResolveHandler<IResourceGetHandler>("First", scope.ServiceProvider);
+        var second = registration.ResolveHandler<IResourceGetHandler>("Second", scope.ServiceProvider);
+
+        first.Should().BeOfType<ConfiguredGetHandler>().Which.Name.Should().Be("first");
+        second.Should().BeOfType<ConfiguredGetHandler>().Which.Name.Should().Be("second");
+    }
+
+    [Fact]
+    public void FactoryCreatedHandler_WhenScopeEnds_IsDisposed()
+    {
+        var services = new ServiceCollection();
+        DisposableGetHandler? createdHandler = null;
+        var registration = BicepExtensionRegistration.Create(services, extension => extension
+            .AddHandler(_ => createdHandler = new DisposableGetHandler()));
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+
+        using (var scope = serviceProvider.CreateScope())
+        {
+            registration.ResolveHandler<IResourceGetHandler>(resourceType: null, scope.ServiceProvider)
+                .Should().BeSameAs(createdHandler);
+        }
+
+        createdHandler.Should().NotBeNull();
+        createdHandler!.Disposed.Should().BeTrue();
+    }
+
+    private class StubGetHandler : IResourceGetHandler
+    {
+        public virtual Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, ErrorResponse>>((Resource?)null);
+    }
+
+    private sealed class SecondGetHandler : StubGetHandler
+    {
+    }
+
+    private sealed class ConfiguredGetHandler : StubGetHandler
+    {
+        public ConfiguredGetHandler(string name)
+        {
+            this.Name = name;
+        }
+
+        public string Name { get; }
+    }
+
+    private sealed class DisposableGetHandler : StubGetHandler, IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            this.Disposed = true;
+        }
+    }
+
+    private sealed class StubLroHandler : ILongRunningOperationGetHandler
+    {
+        public Task<OneOf<LongRunningOperation, ErrorResponse>> HandleAsync(
+            JsonObject request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<LongRunningOperation, ErrorResponse>>(
+                new ErrorResponse(new Error("NotImplemented", "Not implemented.")));
+    }
+
+    private sealed class UnsupportedBehavior : IHandlerBehavior<string, string>
+    {
+        public Task<string> HandleAsync(
+            string request,
+            HandlerDelegate<string, string> next,
+            CancellationToken cancellationToken) => next(request);
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/HandlerInvokerTests.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore.Tests.Unit/Handlers/HandlerInvokerTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Exceptions;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Tests.Unit.Handlers;
+
+public class HandlerInvokerTests
+{
+    [Fact]
+    public async Task Invoke_WithResolvedRegistration_OrdersBehaviors()
+    {
+        var events = new List<string>();
+        var services = new ServiceCollection();
+        services.AddBicepExtensionGlobalHandlerBehavior(_ => new RecordingGetBehavior(events, "global"));
+        var registration = BicepExtensionRegistration.Create(services, extension => extension
+            .AddHandlerBehavior(_ => new RecordingGetBehavior(events, "registration"))
+            .ForResourceType("Widget", resourceType => resourceType
+                .AddHandler(_ => new RecordingGetHandler(events))
+                .AddHandlerBehavior(_ => new RecordingGetBehavior(events, "resource"))));
+        services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        services.AddBicepExtensionHandlerRuntime();
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = serviceProvider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<HandlerInvoker>();
+
+        var result = await sut.InvokeResourceGetAsync("1.0.0", CreateReference(), CancellationToken.None);
+
+        result.IsT0.Should().BeTrue();
+        events.Should().Equal(
+            "global-before",
+            "registration-before",
+            "resource-before",
+            "handler",
+            "resource-after",
+            "registration-after",
+            "global-after");
+    }
+
+    [Fact]
+    public async Task Invoke_WithUnsupportedVersion_RunsGlobalBehaviors()
+    {
+        var events = new List<string>();
+        var services = new ServiceCollection();
+        services.AddBicepExtensionGlobalHandlerBehavior(_ => new RecordingGetBehavior(events, "global"));
+        services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration: null));
+        services.AddBicepExtensionHandlerRuntime();
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = serviceProvider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<HandlerInvoker>();
+
+        var result = await sut.InvokeResourceGetAsync("invalid", CreateReference(), CancellationToken.None);
+
+        result.IsT1.Should().BeTrue();
+        result.AsT1!.Error.Code.Should().Be("UnsupportedExtensionVersion");
+        events.Should().Equal("global-before", "global-after");
+    }
+
+    [Fact]
+    public async Task Invoke_WhenGlobalThrowsErrorResponse_ReturnsError()
+    {
+        var services = new ServiceCollection();
+        services.AddBicepExtensionGlobalHandlerBehavior<ThrowingGetBehavior>();
+        services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration: null));
+        services.AddBicepExtensionHandlerRuntime();
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = serviceProvider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<HandlerInvoker>();
+
+        var result = await sut.InvokeResourceGetAsync("1.0.0", CreateReference(), CancellationToken.None);
+
+        result.IsT1.Should().BeTrue();
+        result.AsT1!.Error.Code.Should().Be("ExpectedFailure");
+    }
+
+    [Fact]
+    public async Task Invoke_WithoutLroHandler_ReturnsUnsupportedOperation()
+    {
+        var services = new ServiceCollection();
+        var registration = BicepExtensionRegistration.Create(services, extension => extension.AddHandler<RecordingGetHandler>());
+        services.AddSingleton<IBicepExtensionResolver>(new StubResolver(registration));
+        services.AddBicepExtensionHandlerRuntime();
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = serviceProvider.CreateScope();
+        var sut = scope.ServiceProvider.GetRequiredService<HandlerInvoker>();
+
+        var result = await sut.InvokeLongRunningOperationGetAsync("1.0.0", [], CancellationToken.None);
+
+        result.IsT1.Should().BeTrue();
+        result.AsT1!.Error.Code.Should().Be("UnsupportedOperation");
+    }
+
+    private static ResourceReference CreateReference() => new()
+    {
+        Type = "Widget",
+        Identifiers = new JsonObject { ["name"] = "example" },
+    };
+
+    private sealed class StubResolver : IBicepExtensionResolver
+    {
+        private readonly BicepExtensionRegistration? registration;
+
+        public StubResolver(BicepExtensionRegistration? registration)
+        {
+            this.registration = registration;
+        }
+
+        public BicepExtensionRegistration? Resolve(string extensionVersion) => this.registration;
+    }
+
+    private sealed class RecordingGetHandler : IResourceGetHandler
+    {
+        private readonly IList<string>? events;
+
+        public RecordingGetHandler()
+        {
+        }
+
+        public RecordingGetHandler(IList<string> events)
+        {
+            this.events = events;
+        }
+
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken)
+        {
+            this.events?.Add("handler");
+
+            return Task.FromResult<OneOf<Resource?, ErrorResponse>>(new Resource
+            {
+                Type = request.Type,
+                Identifiers = request.Identifiers,
+                Properties = new JsonObject { ["name"] = "example" },
+            });
+        }
+    }
+
+    private sealed class RecordingGetBehavior : IResourceGetBehavior
+    {
+        private readonly IList<string> events;
+        private readonly string name;
+
+        public RecordingGetBehavior(IList<string> events, string name)
+        {
+            this.events = events;
+            this.name = name;
+        }
+
+        public async Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            ResourceGetHandlerDelegate next,
+            CancellationToken cancellationToken)
+        {
+            this.events.Add($"{this.name}-before");
+            var result = await next(request);
+            this.events.Add($"{this.name}-after");
+
+            return result;
+        }
+    }
+
+    private sealed class ThrowingGetBehavior : IResourceGetBehavior
+    {
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            ResourceGetHandlerDelegate next,
+            CancellationToken cancellationToken) =>
+            throw new ErrorResponseException("ExpectedFailure", "Expected failure.");
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Azure.Deployments.Extensibility.AspNetCore.csproj
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Azure.Deployments.Extensibility.AspNetCore.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Azure.Deployments.Extensibility.Extensions.Kubernetes" />
+    <InternalsVisibleTo Include="Azure.Deployments.Extensibility.AspNetCore.Tests.Unit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/BicepExtensionBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/BicepExtensionBuilder.cs
@@ -1,0 +1,266 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Azure.Deployments.Extensibility.AspNetCore;
+
+internal sealed class BicepExtensionBuilder : IBicepExtensionBuilder
+{
+    private static readonly Type[] DetectableHandlerInterfaces =
+    [
+        typeof(IResourcePreviewHandler),
+        typeof(IResourceCreateOrUpdateHandler),
+        typeof(IResourceGetHandler),
+        typeof(IResourceDeleteHandler),
+        typeof(ILongRunningOperationGetHandler),
+    ];
+
+    private readonly IServiceCollection services;
+    private readonly Dictionary<Type, ComponentRegistration> defaultHandlers = [];
+    private readonly Dictionary<string, Dictionary<Type, ComponentRegistration>> resourceTypeHandlers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<ComponentRegistration> behaviors = [];
+    private readonly Dictionary<string, List<ComponentRegistration>> resourceTypeBehaviors = new(StringComparer.OrdinalIgnoreCase);
+
+    internal BicepExtensionBuilder(IServiceCollection services)
+    {
+        this.services = services;
+    }
+
+    public IBicepExtensionBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>()
+        where THandler : class, IHandler
+    {
+        this.AddHandler<THandler>(resourceType: null, factory: null);
+        return this;
+    }
+
+    public IBicepExtensionBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>(
+        Func<IServiceProvider, THandler> factory)
+        where THandler : class, IHandler
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        this.AddHandler(resourceType: null, factory);
+        return this;
+    }
+
+    public IBicepExtensionBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>()
+        where TBehavior : class
+    {
+        this.AddBehavior<TBehavior>(resourceType: null, factory: null);
+        return this;
+    }
+
+    public IBicepExtensionBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        Func<IServiceProvider, TBehavior> factory)
+        where TBehavior : class
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        this.AddBehavior(resourceType: null, factory);
+        return this;
+    }
+
+    public IBicepExtensionBuilder ForResourceType(string resourceType, Action<IBicepResourceTypeBuilder> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceType);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(new BicepResourceTypeBuilder(this, resourceType));
+        return this;
+    }
+
+    internal BicepExtensionRegistration Build()
+    {
+        if (this.defaultHandlers.Count == 0 && this.resourceTypeHandlers.Values.All(handlers => handlers.Count == 0))
+        {
+            throw new InvalidOperationException("The Bicep extension registration must contain at least one handler.");
+        }
+
+        return new BicepExtensionRegistration(
+            this.defaultHandlers,
+            this.resourceTypeHandlers,
+            this.behaviors,
+            this.resourceTypeBehaviors);
+    }
+
+    internal void AddResourceTypeHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>(
+        string resourceType,
+        Func<IServiceProvider, THandler>? factory)
+        where THandler : class, IHandler => this.AddHandler(resourceType, factory);
+
+    internal void AddResourceTypeBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        string resourceType,
+        Func<IServiceProvider, TBehavior>? factory)
+        where TBehavior : class => this.AddBehavior(resourceType, factory);
+
+    private void AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>(
+        string? resourceType,
+        Func<IServiceProvider, THandler>? factory)
+        where THandler : class, IHandler
+    {
+        var handlerInterfaces = DetectableHandlerInterfaces
+            .Where(handlerInterface => handlerInterface.IsAssignableFrom(typeof(THandler)))
+            .ToArray();
+
+        if (handlerInterfaces.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Handler type '{typeof(THandler)}' does not implement a supported Bicep extension handler interface.");
+        }
+
+        if (resourceType is not null && handlerInterfaces.Contains(typeof(ILongRunningOperationGetHandler)))
+        {
+            throw new InvalidOperationException(
+                $"Long-running operation handlers cannot be scoped to resource type '{resourceType}'.");
+        }
+
+        var handlers = this.GetHandlers(resourceType);
+        var duplicateInterface = handlerInterfaces.FirstOrDefault(handlers.ContainsKey);
+
+        if (duplicateInterface is not null)
+        {
+            var scope = resourceType is null ? "the default scope" : $"resource type '{resourceType}'";
+            throw new InvalidOperationException(
+                $"A handler for operation '{duplicateInterface}' is already registered in {scope}.");
+        }
+
+        var registration = factory is null
+            ? this.RegisterComponent<THandler>()
+            : this.RegisterComponent(factory);
+
+        foreach (var handlerInterface in handlerInterfaces)
+        {
+            handlers.Add(handlerInterface, registration);
+        }
+    }
+
+    private void AddBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        string? resourceType,
+        Func<IServiceProvider, TBehavior>? factory)
+        where TBehavior : class
+    {
+        if (!HandlerContractTypes.IsSupportedBehavior(typeof(TBehavior)))
+        {
+            throw new InvalidOperationException(
+                $"Behavior type '{typeof(TBehavior)}' does not implement a supported handler behavior interface.");
+        }
+
+        var registration = factory is null
+            ? this.RegisterComponent<TBehavior>()
+            : this.RegisterComponent(factory);
+
+        this.GetBehaviors(resourceType).Add(registration);
+    }
+
+    private Dictionary<Type, ComponentRegistration> GetHandlers(string? resourceType)
+    {
+        if (resourceType is null)
+        {
+            return this.defaultHandlers;
+        }
+
+        if (!this.resourceTypeHandlers.TryGetValue(resourceType, out var handlers))
+        {
+            handlers = [];
+            this.resourceTypeHandlers.Add(resourceType, handlers);
+        }
+
+        return handlers;
+    }
+
+    private List<ComponentRegistration> GetBehaviors(string? resourceType)
+    {
+        if (resourceType is null)
+        {
+            return this.behaviors;
+        }
+
+        if (!this.resourceTypeBehaviors.TryGetValue(resourceType, out var registrations))
+        {
+            registrations = [];
+            this.resourceTypeBehaviors.Add(resourceType, registrations);
+        }
+
+        return registrations;
+    }
+
+    private ComponentRegistration RegisterComponent<TComponent>()
+        where TComponent : class
+    {
+        this.services.TryAddScoped<TComponent>();
+        return new ComponentRegistration(typeof(TComponent));
+    }
+
+    private ComponentRegistration RegisterComponent<TComponent>(Func<IServiceProvider, TComponent> factory)
+        where TComponent : class
+    {
+        var serviceKey = new object();
+        this.services.AddKeyedScoped<TComponent>(serviceKey, (serviceProvider, _) => factory(serviceProvider));
+
+        return new ComponentRegistration(typeof(TComponent), serviceKey);
+    }
+}
+
+internal sealed class BicepResourceTypeBuilder : IBicepResourceTypeBuilder
+{
+    private readonly BicepExtensionBuilder extensionBuilder;
+    private readonly string resourceType;
+
+    internal BicepResourceTypeBuilder(BicepExtensionBuilder extensionBuilder, string resourceType)
+    {
+        this.extensionBuilder = extensionBuilder;
+        this.resourceType = resourceType;
+    }
+
+    public IBicepResourceTypeBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>()
+        where THandler : class, IHandler
+    {
+        this.extensionBuilder.AddResourceTypeHandler<THandler>(this.resourceType, factory: null);
+        return this;
+    }
+
+    public IBicepResourceTypeBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>(
+        Func<IServiceProvider, THandler> factory)
+        where THandler : class, IHandler
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        this.extensionBuilder.AddResourceTypeHandler(this.resourceType, factory);
+        return this;
+    }
+
+    public IBicepResourceTypeBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>()
+        where TBehavior : class
+    {
+        this.extensionBuilder.AddResourceTypeBehavior<TBehavior>(this.resourceType, factory: null);
+        return this;
+    }
+
+    public IBicepResourceTypeBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        Func<IServiceProvider, TBehavior> factory)
+        where TBehavior : class
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        this.extensionBuilder.AddResourceTypeBehavior(this.resourceType, factory);
+        return this;
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepExtensionBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepExtensionBuilder.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Azure.Deployments.Extensibility.AspNetCore;
+
+/// <summary>
+/// Configures a version-independent set of Bicep extension handlers and behaviors.
+/// </summary>
+public interface IBicepExtensionBuilder
+{
+    /// <summary>
+    /// Registers a default handler by resolving it from the current request scope.
+    /// </summary>
+    IBicepExtensionBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>()
+        where THandler : class, IHandler;
+
+    /// <summary>
+    /// Registers a default handler using a factory invoked against the current request scope.
+    /// </summary>
+    IBicepExtensionBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>(
+        Func<IServiceProvider, THandler> factory)
+        where THandler : class, IHandler;
+
+    /// <summary>
+    /// Registers a behavior that applies to handlers in this extension registration.
+    /// </summary>
+    IBicepExtensionBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>()
+        where TBehavior : class;
+
+    /// <summary>
+    /// Registers a behavior factory invoked against the current request scope.
+    /// </summary>
+    IBicepExtensionBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        Func<IServiceProvider, TBehavior> factory)
+        where TBehavior : class;
+
+    /// <summary>
+    /// Configures handlers and behaviors scoped to <paramref name="resourceType"/>.
+    /// </summary>
+    IBicepExtensionBuilder ForResourceType(
+        string resourceType,
+        Action<IBicepResourceTypeBuilder> configure);
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepResourceTypeBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepResourceTypeBuilder.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Azure.Deployments.Extensibility.AspNetCore;
+
+/// <summary>
+/// Configures handlers and behaviors for one Bicep resource type.
+/// </summary>
+public interface IBicepResourceTypeBuilder
+{
+    /// <summary>
+    /// Registers a handler by resolving it from the current request scope.
+    /// </summary>
+    IBicepResourceTypeBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>()
+        where THandler : class, IHandler;
+
+    /// <summary>
+    /// Registers a handler using a factory invoked against the current request scope.
+    /// </summary>
+    IBicepResourceTypeBuilder AddHandler<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] THandler>(
+        Func<IServiceProvider, THandler> factory)
+        where THandler : class, IHandler;
+
+    /// <summary>
+    /// Registers a behavior that applies to this resource type.
+    /// </summary>
+    IBicepResourceTypeBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>()
+        where TBehavior : class;
+
+    /// <summary>
+    /// Registers a behavior factory invoked against the current request scope.
+    /// </summary>
+    IBicepResourceTypeBuilder AddHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        Func<IServiceProvider, TBehavior> factory)
+        where TBehavior : class;
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/BicepExtensionApplicationBuilderExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/BicepExtensionApplicationBuilderExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Middlewares;
+using Microsoft.AspNetCore.Builder;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Extensions;
+
+/// <summary>
+/// Extension methods for configuring Bicep extension middleware.
+/// </summary>
+public static class BicepExtensionApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds request culture handling to the application pipeline.
+    /// </summary>
+    public static IApplicationBuilder UseBicepExtensionRequestCulture(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        return app.UseMiddleware<RequestCultureMiddleware>();
+    }
+
+    /// <summary>
+    /// Adds request correlation handling to the application pipeline.
+    /// </summary>
+    public static IApplicationBuilder UseBicepExtensionRequestCorrelation(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        return app.UseMiddleware<RequestCorrelationMiddleware>();
+    }
+
+    /// <summary>
+    /// Adds the shared exception, request culture, and request correlation middleware.
+    /// </summary>
+    public static IApplicationBuilder UseBicepExtensionMiddlewares(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.UseExceptionHandler();
+        app.UseWhen(IsBicepExtensionRequest, branch =>
+        {
+            branch.UseBicepExtensionRequestCulture();
+            branch.UseBicepExtensionRequestCorrelation();
+        });
+
+        return app;
+    }
+
+    private static bool IsBicepExtensionRequest(Microsoft.AspNetCore.Http.HttpContext context) =>
+        context.Request.Path.Value?.Contains("/resource/", StringComparison.OrdinalIgnoreCase) == true ||
+        context.Request.Path.Value?.Contains("/longRunningOperation/", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/BicepExtensionEndpointRouteBuilderExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/BicepExtensionEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Extensions;
+
+/// <summary>
+/// Extension methods for mapping Bicep extension endpoints.
+/// </summary>
+public static class BicepExtensionEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the resource preview, create-or-update, get, and delete endpoints.
+    /// </summary>
+    public static IEndpointConventionBuilder MapResourceActions(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ValidateRuntime(endpoints);
+
+        var group = endpoints.MapGroup(string.Empty);
+        MapResourceActionEndpoints(group);
+
+        return group;
+    }
+
+    /// <summary>
+    /// Maps the long-running operation status endpoint.
+    /// </summary>
+    public static IEndpointConventionBuilder MapLongRunningOperationActions(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ValidateRuntime(endpoints);
+
+        return endpoints.MapPost(
+            "/{extensionVersion}/longRunningOperation/get",
+            BicepExtensionHandlerDispatcher.DispatchLongRunningOperationGetAsync);
+    }
+
+    /// <summary>
+    /// Maps all Bicep extension contract endpoints.
+    /// </summary>
+    public static IEndpointConventionBuilder MapBicepExtensionEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ValidateRuntime(endpoints);
+
+        var group = endpoints.MapGroup(string.Empty);
+        MapResourceActionEndpoints(group);
+        group.MapPost(
+            "/{extensionVersion}/longRunningOperation/get",
+            BicepExtensionHandlerDispatcher.DispatchLongRunningOperationGetAsync);
+
+        return group;
+    }
+
+    private static void MapResourceActionEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost(
+            "/{extensionVersion}/resource/preview",
+            BicepExtensionHandlerDispatcher.DispatchResourcePreviewAsync);
+        endpoints.MapPost(
+            "/{extensionVersion}/resource/createOrUpdate",
+            BicepExtensionHandlerDispatcher.DispatchResourceCreateOrUpdateAsync);
+        endpoints.MapPost(
+            "/{extensionVersion}/resource/get",
+            BicepExtensionHandlerDispatcher.DispatchResourceGetAsync);
+        endpoints.MapPost(
+            "/{extensionVersion}/resource/delete",
+            BicepExtensionHandlerDispatcher.DispatchResourceDeleteAsync);
+    }
+
+    private static void ValidateRuntime(IEndpointRouteBuilder endpoints)
+    {
+        var resolvers = endpoints.ServiceProvider.GetServices<IBicepExtensionResolver>().Take(2).ToArray();
+
+        if (resolvers.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Exactly one {nameof(IBicepExtensionResolver)} must be registered before mapping Bicep extension endpoints.");
+        }
+
+        var serviceProviderIsService = endpoints.ServiceProvider.GetService<IServiceProviderIsService>();
+
+        if (serviceProviderIsService?.IsService(typeof(HandlerInvoker)) != true)
+        {
+            throw new InvalidOperationException(
+                $"Call {nameof(BicepExtensionServiceCollectionExtensions.AddBicepExtensionHandlerRuntime)} before mapping Bicep extension endpoints.");
+        }
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/BicepExtensionServiceCollectionExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/BicepExtensionServiceCollectionExtensions.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.AspNetCore.ExceptionHandlers;
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering the shared Bicep extension runtime.
+/// </summary>
+public static class BicepExtensionServiceCollectionExtensions
+{
+    /// <summary>
+    /// Configures the JSON serialization defaults required by Bicep extension handlers.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionJsonOptions(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.Configure<JsonOptions>(options =>
+        {
+            options.SerializerOptions.TypeInfoResolverChain.Insert(0, JsonDefaults.SerializerContext);
+            options.SerializerOptions.PropertyNamingPolicy = JsonDefaults.SerializerOptions.PropertyNamingPolicy;
+            options.SerializerOptions.DictionaryKeyPolicy = JsonDefaults.SerializerOptions.DictionaryKeyPolicy;
+            options.SerializerOptions.DefaultIgnoreCondition = JsonDefaults.SerializerOptions.DefaultIgnoreCondition;
+            options.SerializerOptions.Encoder = JsonDefaults.SerializerOptions.Encoder;
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the default exception handler for unexpected exceptions.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionExceptionHandler(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddExceptionHandler<DefaultExceptionHandler>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers problem details formatting that conforms to the Bicep extensibility API contract.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionProblemDetails(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddProblemDetails(options =>
+        {
+            options.CustomizeProblemDetails = context =>
+            {
+                if (context.ProblemDetails.Extensions.ContainsKey("error"))
+                {
+                    return;
+                }
+
+                var title = context.ProblemDetails.Title;
+                var detail = context.ProblemDetails.Detail;
+                var status = context.ProblemDetails.Status;
+
+                context.ProblemDetails.Extensions.Clear();
+                context.ProblemDetails.Type = null;
+                context.ProblemDetails.Title = null;
+                context.ProblemDetails.Detail = null;
+                context.ProblemDetails.Instance = null;
+
+                context.HttpContext.Response.StatusCode = status ?? StatusCodes.Status500InternalServerError;
+                context.ProblemDetails.Status = null;
+                context.ProblemDetails.Extensions["error"] = new Dictionary<string, object>
+                {
+                    ["code"] = !string.IsNullOrWhiteSpace(title)
+                        ? title
+                        : status?.ToString() ?? "UnknownProblem",
+                    ["message"] = detail ?? title ?? "An unknown problem occurred.",
+                };
+            };
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the shared handler invocation runtime.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionHandlerRuntime(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddOptions<BicepExtensionRuntimeOptions>();
+        services.TryAddScoped<HandlerInvoker>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the shared services used by a Bicep extension host.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddBicepExtensionJsonOptions();
+        services.AddBicepExtensionExceptionHandler();
+        services.AddBicepExtensionProblemDetails();
+        services.AddBicepExtensionHandlerRuntime();
+        services.AddHttpContextAccessor();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a behavior that wraps every handler invocation, including unsupported versions.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionGlobalHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        this IServiceCollection services)
+        where TBehavior : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ValidateBehavior<TBehavior>();
+
+        services.TryAddScoped<TBehavior>();
+        AddGlobalBehavior(services, new ComponentRegistration(typeof(TBehavior)));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a behavior factory that wraps every handler invocation, including unsupported versions.
+    /// </summary>
+    public static IServiceCollection AddBicepExtensionGlobalHandlerBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>(
+        this IServiceCollection services,
+        Func<IServiceProvider, TBehavior> factory)
+        where TBehavior : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(factory);
+        ValidateBehavior<TBehavior>();
+
+        var serviceKey = new object();
+        services.AddKeyedScoped<TBehavior>(serviceKey, (serviceProvider, _) => factory(serviceProvider));
+        AddGlobalBehavior(services, new ComponentRegistration(typeof(TBehavior), serviceKey));
+
+        return services;
+    }
+
+    private static void AddGlobalBehavior(IServiceCollection services, ComponentRegistration registration)
+    {
+        services.AddOptions<BicepExtensionRuntimeOptions>()
+            .Configure(options => options.GlobalBehaviors.Add(registration));
+    }
+
+    private static void ValidateBehavior<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] TBehavior>()
+        where TBehavior : class
+    {
+        if (!HandlerContractTypes.IsSupportedBehavior(typeof(TBehavior)))
+        {
+            throw new InvalidOperationException(
+                $"Behavior type '{typeof(TBehavior)}' does not implement a supported handler behavior interface.");
+        }
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Deployments.Extensibility.AspNetCore.ExceptionHandlers;
-using Azure.Deployments.Extensibility.Core.V2.Json;
-using Azure.Deployments.Extensibility.Core.V2.Models;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Deployments.Extensibility.AspNetCore.Extensions;
@@ -22,60 +17,11 @@ internal static class WebApplicationBuilderExtensions
     /// </summary>
     public static WebApplicationBuilder AddExtensionInfrastructure(this WebApplicationBuilder builder)
     {
-        builder.Services.Configure<JsonOptions>(options =>
-        {
-            options.SerializerOptions.TypeInfoResolverChain.Insert(0, JsonDefaults.SerializerContext);
-            options.SerializerOptions.PropertyNamingPolicy = JsonDefaults.SerializerOptions.PropertyNamingPolicy;
-            options.SerializerOptions.DictionaryKeyPolicy = JsonDefaults.SerializerOptions.DictionaryKeyPolicy;
-            options.SerializerOptions.DefaultIgnoreCondition = JsonDefaults.SerializerOptions.DefaultIgnoreCondition;
-            options.SerializerOptions.Encoder = JsonDefaults.SerializerOptions.Encoder;
-        });
-
+        builder.Services.AddBicepExtensionJsonOptions();
+        builder.Services.AddBicepExtensionExceptionHandler();
+        builder.Services.AddBicepExtensionProblemDetails();
         builder.Services.AddHttpContextAccessor();
-        builder.Services.AddExceptionHandler<DefaultExceptionHandler>();
-        builder.Services.AddExtensibilityApiCompliantProblemDetails();
 
         return builder;
-    }
-
-    private static IServiceCollection AddExtensibilityApiCompliantProblemDetails(this IServiceCollection services)
-    {
-        services.AddProblemDetails(options =>
-        {
-            options.CustomizeProblemDetails = context =>
-            {
-                if (context.ProblemDetails.Extensions.ContainsKey("error"))
-                {
-                    // Avoid double-wrapping if already done.
-                    return;
-                }
-
-                var title = context.ProblemDetails.Title;
-                var detail = context.ProblemDetails.Detail;
-                var status = context.ProblemDetails.Status;
-
-                context.ProblemDetails.Extensions.Clear();
-                context.ProblemDetails.Type = null;
-                context.ProblemDetails.Title = null;
-                context.ProblemDetails.Detail = null;
-                context.ProblemDetails.Instance = null;
-
-                // set HTTP status before clearing it from problem details
-                context.HttpContext.Response.StatusCode = status ?? StatusCodes.Status500InternalServerError;
-                context.ProblemDetails.Status = null;
-
-                var errorObj = new Dictionary<string, object>
-                {
-                    ["code"] = !string.IsNullOrWhiteSpace(title)
-                        ? title
-                        : status?.ToString() ?? "UnknownProblem",
-                    ["message"] = detail ?? title ?? "An unknown problem occurred."
-                };
-
-                context.ProblemDetails.Extensions["error"] = errorObj;
-            };
-        });
-
-        return services;
     }
 }

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/BicepExtensionHandlerDispatcher.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/BicepExtensionHandlerDispatcher.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Models;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json.Nodes;
+
+using static Microsoft.AspNetCore.Http.TypedResults;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Handlers;
+
+internal static class BicepExtensionHandlerDispatcher
+{
+    public static async Task<IResult> DispatchResourcePreviewAsync(
+        string extensionVersion,
+        ResourcePreviewSpecification request,
+        [FromServices] HandlerInvoker handlerInvoker,
+        CancellationToken cancellationToken)
+    {
+        var response = await handlerInvoker.InvokeResourcePreviewAsync(extensionVersion, request, cancellationToken);
+
+        return response.Match(
+            resourcePreview => Ok(resourcePreview),
+            ErrorResponseToHttpResult);
+    }
+
+    public static async Task<IResult> DispatchResourceCreateOrUpdateAsync(
+        string extensionVersion,
+        ResourceSpecification request,
+        [FromServices] HandlerInvoker handlerInvoker,
+        CancellationToken cancellationToken)
+    {
+        var response = await handlerInvoker.InvokeResourceCreateOrUpdateAsync(extensionVersion, request, cancellationToken);
+
+        return response.Match(
+            resource => Ok(resource),
+            longRunningOperation => Accepted(uri: (string?)null, longRunningOperation),
+            ErrorResponseToHttpResult);
+    }
+
+    public static async Task<IResult> DispatchResourceGetAsync(
+        string extensionVersion,
+        ResourceReference request,
+        [FromServices] HandlerInvoker handlerInvoker,
+        CancellationToken cancellationToken)
+    {
+        var response = await handlerInvoker.InvokeResourceGetAsync(extensionVersion, request, cancellationToken);
+
+        return response.Match(
+            resource => resource is null
+                ? NotFound(new ErrorResponse(new Error(
+                    "ResourceNotFound",
+                    $"The resource of type {request.Type} with api version {request.ApiVersion} and identifiers {request.Identifiers} was not found.")))
+                : Ok(resource),
+            ErrorResponseToHttpResult);
+    }
+
+    public static async Task<IResult> DispatchResourceDeleteAsync(
+        string extensionVersion,
+        ResourceReference request,
+        [FromServices] HandlerInvoker handlerInvoker,
+        CancellationToken cancellationToken)
+    {
+        var response = await handlerInvoker.InvokeResourceDeleteAsync(extensionVersion, request, cancellationToken);
+
+        return response.Match(
+            resource => resource is null ? NoContent() : Ok(resource),
+            longRunningOperation => Accepted(uri: (string?)null, longRunningOperation),
+            ErrorResponseToHttpResult);
+    }
+
+    public static async Task<IResult> DispatchLongRunningOperationGetAsync(
+        string extensionVersion,
+        JsonObject request,
+        [FromServices] HandlerInvoker handlerInvoker,
+        CancellationToken cancellationToken)
+    {
+        var response = await handlerInvoker.InvokeLongRunningOperationGetAsync(extensionVersion, request, cancellationToken);
+
+        return response.Match(
+            longRunningOperation => Ok(longRunningOperation),
+            ErrorResponseToHttpResult);
+    }
+
+    private static IResult ErrorResponseToHttpResult(ErrorResponse errorResponse) => errorResponse is HttpErrorResponse httpErrorResponse
+        ? TypedResults.Json(httpErrorResponse.AsErrorResponse(), statusCode: httpErrorResponse.StatusCode)
+        : BadRequest(errorResponse);
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/BicepExtensionRegistration.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/BicepExtensionRegistration.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.AspNetCore.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Deployments.Extensibility.AspNetCore;
+
+/// <summary>
+/// Represents an immutable, version-independent Bicep extension handler registration.
+/// </summary>
+public sealed class BicepExtensionRegistration
+{
+    private readonly IReadOnlyDictionary<Type, ComponentRegistration> defaultHandlers;
+    private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<Type, ComponentRegistration>> resourceTypeHandlers;
+    private readonly IReadOnlyList<ComponentRegistration> behaviors;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<ComponentRegistration>> resourceTypeBehaviors;
+
+    internal BicepExtensionRegistration(
+        IReadOnlyDictionary<Type, ComponentRegistration> defaultHandlers,
+        IReadOnlyDictionary<string, Dictionary<Type, ComponentRegistration>> resourceTypeHandlers,
+        IReadOnlyList<ComponentRegistration> behaviors,
+        IReadOnlyDictionary<string, List<ComponentRegistration>> resourceTypeBehaviors)
+    {
+        this.defaultHandlers = new Dictionary<Type, ComponentRegistration>(defaultHandlers);
+        this.resourceTypeHandlers = resourceTypeHandlers.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyDictionary<Type, ComponentRegistration>)new Dictionary<Type, ComponentRegistration>(pair.Value),
+            StringComparer.OrdinalIgnoreCase);
+        this.behaviors = behaviors.ToArray();
+        this.resourceTypeBehaviors = resourceTypeBehaviors.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<ComponentRegistration>)pair.Value.ToArray(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Creates an immutable registration and adds its handler and behavior services to
+    /// <paramref name="services"/>.
+    /// </summary>
+    public static BicepExtensionRegistration Create(
+        IServiceCollection services,
+        Action<IBicepExtensionBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var builder = new BicepExtensionBuilder(services);
+        configure(builder);
+
+        return builder.Build();
+    }
+
+    internal THandler? ResolveHandler<THandler>(string? resourceType, IServiceProvider serviceProvider)
+        where THandler : class, IHandler
+    {
+        var handlerType = typeof(THandler);
+
+        if (resourceType is not null &&
+            this.resourceTypeHandlers.TryGetValue(resourceType, out var handlers) &&
+            handlers.TryGetValue(handlerType, out var resourceTypeRegistration))
+        {
+            return (THandler)resourceTypeRegistration.Resolve(serviceProvider);
+        }
+
+        return this.defaultHandlers.TryGetValue(handlerType, out var defaultRegistration)
+            ? (THandler)defaultRegistration.Resolve(serviceProvider)
+            : null;
+    }
+
+    internal IReadOnlyList<IHandlerBehavior<TRequest, TResponse>> ResolveBehaviors<TRequest, TResponse>(
+        string? resourceType,
+        IServiceProvider serviceProvider)
+    {
+        var registrations = new List<ComponentRegistration>(this.behaviors);
+
+        if (resourceType is not null && this.resourceTypeBehaviors.TryGetValue(resourceType, out var resourceBehaviors))
+        {
+            registrations.AddRange(resourceBehaviors);
+        }
+
+        return registrations
+            .Select(registration => registration.Resolve(serviceProvider))
+            .OfType<IHandlerBehavior<TRequest, TResponse>>()
+            .ToArray();
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/BicepExtensionRuntimeOptions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/BicepExtensionRuntimeOptions.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Handlers;
+
+internal sealed class BicepExtensionRuntimeOptions
+{
+    internal List<ComponentRegistration> GlobalBehaviors { get; } = [];
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/ComponentRegistration.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/ComponentRegistration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Handlers;
+
+internal sealed class ComponentRegistration
+{
+    private readonly Type serviceType;
+    private readonly object? serviceKey;
+
+    internal ComponentRegistration(Type serviceType, object? serviceKey = null)
+    {
+        this.serviceType = serviceType;
+        this.serviceKey = serviceKey;
+    }
+
+    internal object Resolve(IServiceProvider serviceProvider) => this.serviceKey is null
+        ? serviceProvider.GetRequiredService(this.serviceType)
+        : serviceProvider.GetRequiredKeyedService(this.serviceType, this.serviceKey);
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/HandlerContractTypes.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/HandlerContractTypes.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using System.Text.Json.Nodes;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Handlers;
+
+internal static class HandlerContractTypes
+{
+    private static readonly Type[] SupportedBehaviorInterfaces =
+    [
+        typeof(IHandlerBehavior<ResourcePreviewSpecification, OneOf<ResourcePreview, ErrorResponse>>),
+        typeof(IHandlerBehavior<ResourceSpecification, OneOf<Resource, LongRunningOperation, ErrorResponse>>),
+        typeof(IHandlerBehavior<ResourceReference, OneOf<Resource?, ErrorResponse>>),
+        typeof(IHandlerBehavior<ResourceReference, OneOf<Resource?, LongRunningOperation, ErrorResponse>>),
+        typeof(IHandlerBehavior<JsonObject, OneOf<LongRunningOperation, ErrorResponse>>),
+    ];
+
+    internal static bool IsSupportedBehavior(Type behaviorType) =>
+        SupportedBehaviorInterfaces.Any(@interface => @interface.IsAssignableFrom(behaviorType));
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/HandlerInvoker.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/HandlerInvoker.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
+using Azure.Deployments.Extensibility.Core.V2.Contracts;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Exceptions;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using Microsoft.Extensions.Options;
+using System.Text.Json.Nodes;
+
+namespace Azure.Deployments.Extensibility.AspNetCore.Handlers;
+
+internal sealed class HandlerInvoker
+{
+    private readonly IBicepExtensionResolver resolver;
+    private readonly IServiceProvider serviceProvider;
+    private readonly BicepExtensionRuntimeOptions options;
+
+    public HandlerInvoker(
+        IBicepExtensionResolver resolver,
+        IServiceProvider serviceProvider,
+        IOptions<BicepExtensionRuntimeOptions> options)
+    {
+        this.resolver = resolver;
+        this.serviceProvider = serviceProvider;
+        this.options = options.Value;
+    }
+
+    internal Task<OneOf<ResourcePreview, ErrorResponse>> InvokeResourcePreviewAsync(
+        string extensionVersion,
+        ResourcePreviewSpecification request,
+        CancellationToken cancellationToken) => this.InvokeAsync<
+            IResourcePreviewHandler,
+            ResourcePreviewSpecification,
+            OneOf<ResourcePreview, ErrorResponse>>(
+                extensionVersion,
+                request.Type,
+                request,
+                new ErrorResponse(new Error(
+                    "UnsupportedResourceType",
+                    $"The resource type '{request.Type}' is not supported.")),
+                static errorResponse => errorResponse,
+                cancellationToken);
+
+    internal Task<OneOf<Resource, LongRunningOperation, ErrorResponse>> InvokeResourceCreateOrUpdateAsync(
+        string extensionVersion,
+        ResourceSpecification request,
+        CancellationToken cancellationToken) => this.InvokeAsync<
+            IResourceCreateOrUpdateHandler,
+            ResourceSpecification,
+            OneOf<Resource, LongRunningOperation, ErrorResponse>>(
+                extensionVersion,
+                request.Type,
+                request,
+                new ErrorResponse(new Error(
+                    "UnsupportedResourceType",
+                    $"The resource type '{request.Type}' is not supported.")),
+                static errorResponse => errorResponse,
+                cancellationToken);
+
+    internal Task<OneOf<Resource?, ErrorResponse>> InvokeResourceGetAsync(
+        string extensionVersion,
+        ResourceReference request,
+        CancellationToken cancellationToken) => this.InvokeAsync<
+            IResourceGetHandler,
+            ResourceReference,
+            OneOf<Resource?, ErrorResponse>>(
+                extensionVersion,
+                request.Type,
+                request,
+                new ErrorResponse(new Error(
+                    "UnsupportedResourceType",
+                    $"The resource type '{request.Type}' is not supported.")),
+                static errorResponse => errorResponse,
+                cancellationToken);
+
+    internal Task<OneOf<Resource?, LongRunningOperation, ErrorResponse>> InvokeResourceDeleteAsync(
+        string extensionVersion,
+        ResourceReference request,
+        CancellationToken cancellationToken) => this.InvokeAsync<
+            IResourceDeleteHandler,
+            ResourceReference,
+            OneOf<Resource?, LongRunningOperation, ErrorResponse>>(
+                extensionVersion,
+                request.Type,
+                request,
+                new ErrorResponse(new Error(
+                    "UnsupportedResourceType",
+                    $"The resource type '{request.Type}' is not supported.")),
+                static errorResponse => errorResponse,
+                cancellationToken);
+
+    internal Task<OneOf<LongRunningOperation, ErrorResponse>> InvokeLongRunningOperationGetAsync(
+        string extensionVersion,
+        JsonObject request,
+        CancellationToken cancellationToken) => this.InvokeAsync<
+            ILongRunningOperationGetHandler,
+            JsonObject,
+            OneOf<LongRunningOperation, ErrorResponse>>(
+                extensionVersion,
+                resourceType: null,
+                request,
+                new ErrorResponse(new Error(
+                    "UnsupportedOperation",
+                    "Long-running operation status retrieval is not supported.")),
+                static errorResponse => errorResponse,
+                cancellationToken);
+
+    private async Task<TResponse> InvokeAsync<THandler, TRequest, TResponse>(
+        string extensionVersion,
+        string? resourceType,
+        TRequest request,
+        ErrorResponse missingHandlerResponse,
+        Func<ErrorResponse, TResponse> toResponse,
+        CancellationToken cancellationToken)
+        where THandler : class, IHandler<TRequest, TResponse>
+    {
+        var registration = new Lazy<BicepExtensionRegistration?>(
+            () => this.resolver.Resolve(extensionVersion),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        HandlerDelegate<TRequest, TResponse> invokeRegistration = async currentRequest =>
+        {
+            if (registration.Value is not { } resolvedRegistration)
+            {
+                return toResponse(new ErrorResponse(new Error(
+                    "UnsupportedExtensionVersion",
+                    $"No handler found for extension version '{extensionVersion}'.")));
+            }
+
+            var handler = resolvedRegistration.ResolveHandler<THandler>(resourceType, this.serviceProvider);
+
+            if (handler is null)
+            {
+                return toResponse(missingHandlerResponse);
+            }
+
+            var behaviors = resolvedRegistration.ResolveBehaviors<TRequest, TResponse>(resourceType, this.serviceProvider);
+
+            return await ExecuteBehaviorChainAsync(
+                currentRequest,
+                behaviors,
+                innerRequest => handler.HandleAsync(innerRequest, cancellationToken),
+                cancellationToken);
+        };
+
+        try
+        {
+            var globalBehaviors = this.options.GlobalBehaviors
+                .Select(behavior => behavior.Resolve(this.serviceProvider))
+                .OfType<IHandlerBehavior<TRequest, TResponse>>()
+                .ToArray();
+
+            return await ExecuteBehaviorChainAsync(
+                request,
+                globalBehaviors,
+                invokeRegistration,
+                cancellationToken);
+        }
+        catch (ErrorResponseException exception)
+        {
+            return toResponse(exception.ToErrorResponse());
+        }
+    }
+
+    private static Task<TResponse> ExecuteBehaviorChainAsync<TRequest, TResponse>(
+        TRequest request,
+        IReadOnlyList<IHandlerBehavior<TRequest, TResponse>> behaviors,
+        HandlerDelegate<TRequest, TResponse> innerHandler,
+        CancellationToken cancellationToken)
+    {
+        var next = innerHandler;
+
+        for (var index = behaviors.Count - 1; index >= 0; index--)
+        {
+            var behavior = behaviors[index];
+            var current = next;
+            next = currentRequest => behavior.HandleAsync(currentRequest, current, cancellationToken);
+        }
+
+        return next(request);
+    }
+}

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/IBicepExtensionResolver.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Handlers/IBicepExtensionResolver.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Deployments.Extensibility.AspNetCore;
+
+/// <summary>
+/// Resolves the Bicep extension registration that handles an exact extension version from the request route.
+/// </summary>
+public interface IBicepExtensionResolver
+{
+    /// <summary>
+    /// Resolves <paramref name="extensionVersion"/>, or returns <see langword="null"/> when the version
+    /// is malformed or unsupported.
+    /// </summary>
+    BicepExtensionRegistration? Resolve(string extensionVersion);
+}


### PR DESCRIPTION
## Summary

- add version-independent handler and behavior authoring contracts backed by immutable `BicepExtensionRegistration` instances
- add the host-owned `IBicepExtensionResolver` boundary and internal scoped invocation/HTTP dispatch runtime
- expose granular service, middleware, and endpoint helpers for standard ASP.NET Core hosts, including route-group integration
- use keyed scoped DI for factory registrations so configured instances remain independent and are disposed with the request scope
- preserve the existing range-aware `ExtensionApplication` path during consumer migration
- document the ordered follow-up work for FirstParty/Managed hosting SDKs and eventual legacy removal

## Runtime behavior

- global behaviors wrap unsupported or malformed extension versions
- registration and resource behaviors preserve outer-to-inner registration order
- missing resource and LRO handlers return protocol errors instead of sentinel casts
- HTTP-specific error responses preserve their status codes
- endpoint mapping fails fast unless exactly one resolver and the shared invocation runtime are registered

## Validation

- full solution build: 0 warnings, 0 errors
- all unit-test projects: 102 passed
- packed public-only consumer build: 0 warnings, 0 errors
- legacy `ExtensionApplication` build validated with Development service-provider checks
- editor diagnostics and whitespace checks passed