### PR TITLE
Refine managed hosting SDK public API

### DIFF
--- a/docs/contract/async-operations.md
+++ b/docs/contract/async-operations.md
@@ -70,39 +70,23 @@ The `status` field is an open union. Extensions may define custom non-terminal v
    - **Create or update:** The get response includes the `Resource` with `status: "Succeeded"`.
    - **Delete:** The get response returns a not-found error, which the Extensibility Host interprets as a successful deletion.
 
-#### Create or Update
+#### Create or Update flow
 
-```mermaid
-sequenceDiagram
-    participant Host as Extensibility Host
-    participant Ext as Extension
+1. The Extensibility Host sends `createOrUpdate`.
+2. The extension returns `Resource` with `status: "Running"`.
+3. The Extensibility Host sends `get`.
+4. The extension returns `Resource` with `status: "Running"`.
+5. The Extensibility Host sends `get`.
+6. The extension returns `Resource` with `status: "Succeeded"`.
 
-    Host->>Ext: createOrUpdate
-    Ext-->>Host: Resource (status: Running)
+#### Delete flow
 
-    Host->>Ext: get
-    Ext-->>Host: Resource (status: Running)
-
-    Host->>Ext: get
-    Ext-->>Host: Resource (status: Succeeded)
-```
-
-#### Delete
-
-```mermaid
-sequenceDiagram
-    participant Host as Extensibility Host
-    participant Ext as Extension
-
-    Host->>Ext: delete
-    Ext-->>Host: Resource (status: Deleting)
-
-    Host->>Ext: get
-    Ext-->>Host: Resource (status: Deleting)
-
-    Host->>Ext: get
-    Ext-->>Host: ErrorResponse (ResourceNotFound)
-```
+1. The Extensibility Host sends `delete`.
+2. The extension returns `Resource` with `status: "Deleting"`.
+3. The Extensibility Host sends `get`.
+4. The extension returns `Resource` with `status: "Deleting"`.
+5. The Extensibility Host sends `get`.
+6. The extension returns `ErrorResponse` with `ResourceNotFound`.
 
 ### Key Rules
 
@@ -347,42 +331,25 @@ This failed state must persist across subsequent get requests until the user ini
 
 The flow differs slightly between create/update and delete: after a successful create or update, the Extensibility Host issues a final get to retrieve the resource state. Delete does not require a final get.
 
-#### Create or Update
+#### Create or Update flow
 
-```mermaid
-sequenceDiagram
-    participant Host as Extensibility Host
-    participant Ext as Extension
+1. The Extensibility Host sends `createOrUpdate`.
+2. The extension returns `LongRunningOperation` with `status: "Running"` and an operation handle.
+3. The Extensibility Host sends `getLongRunningOperation` with the handle.
+4. The extension returns `LongRunningOperation` with `status: "Running"` and a retry interval.
+5. The Extensibility Host sends `getLongRunningOperation` with the handle.
+6. The extension returns `LongRunningOperation` with `status: "Succeeded"`.
+7. The Extensibility Host sends `get`.
+8. The extension returns `Resource` with `status: "Succeeded"`.
 
-    Host->>Ext: createOrUpdate
-    Ext-->>Host: LRO (status: Running, handle: ...)
+#### Delete flow
 
-    Host->>Ext: getLongRunningOperation(handle)
-    Ext-->>Host: LRO (status: Running, retry: 10)
-
-    Host->>Ext: getLongRunningOperation(handle)
-    Ext-->>Host: LRO (status: Succeeded)
-
-    Host->>Ext: get
-    Ext-->>Host: Resource (status: Succeeded)
-```
-
-#### Delete
-
-```mermaid
-sequenceDiagram
-    participant Host as Extensibility Host
-    participant Ext as Extension
-
-    Host->>Ext: delete
-    Ext-->>Host: LRO (status: Deleting, handle: ...)
-
-    Host->>Ext: getLongRunningOperation(handle)
-    Ext-->>Host: LRO (status: Deleting, retry: 10)
-
-    Host->>Ext: getLongRunningOperation(handle)
-    Ext-->>Host: LRO (status: Succeeded)
-```
+1. The Extensibility Host sends `delete`.
+2. The extension returns `LongRunningOperation` with `status: "Deleting"` and an operation handle.
+3. The Extensibility Host sends `getLongRunningOperation` with the handle.
+4. The extension returns `LongRunningOperation` with `status: "Deleting"` and a retry interval.
+5. The Extensibility Host sends `getLongRunningOperation` with the handle.
+6. The extension returns `LongRunningOperation` with `status: "Succeeded"`.
 
 ### Key Rules
 

--- a/docs/filterConfig.yml
+++ b/docs/filterConfig.yml
@@ -7,7 +7,7 @@ apiRules:
       uidRegex: ^Microsoft\.Extensions\.DependencyInjection\.BicepManagedServiceCollectionExtensions$
       type: Type
 
-  # Exclude BCL and framework namespaces — only Extensibility types should appear
+  # Exclude BCL and framework namespaces - only Extensibility types should appear
   - exclude:
       uidRegex: ^System\.
       type: Namespace
@@ -28,27 +28,27 @@ apiRules:
         uid: System.Runtime.CompilerServices.InternalsVisibleToAttribute
       type: Member
 
-  # Legacy V1 provider types — superseded by V2 contract
+  # Legacy V1 provider types - superseded by V2 contract
   - exclude:
       uidRegex: ^Azure\.Deployments\.Extensibility\.Core\.(IExtensibilityProvider|IExtensibilityProviderRegistry|ModelMapper|Extensib|ExtensibleImport|ExtensibleResource)
       type: Type
 
-  # Internal exception types — not part of the public SDK surface
+  # Internal exception types - not part of the public SDK surface
   - exclude:
       uidRegex: ^Azure\.Deployments\.Extensibility\.Core\.Exceptions\.
       type: Type
 
-  # Internal extension methods — implementation details
+  # Internal extension methods - implementation details
   - exclude:
       uidRegex: ^Azure\.Deployments\.Extensibility\.Core\.Extensions\.
       type: Type
 
-  # Internal JSON serialization helpers — not intended for consumers
+  # Internal JSON serialization helpers - not intended for consumers
   - exclude:
       uidRegex: ^Azure\.Deployments\.Extensibility\.Core\.Json\.(ExtensibilityJsonSerializer|ExtensibilityOperationResponseConverter|ObjectElement)
       type: Type
 
-  # Internal V1 validators — replaced by the V2 fluent validation framework
+  # Internal V1 validators - replaced by the V2 fluent validation framework
   - exclude:
       uidRegex: ^Azure\.Deployments\.Extensibility\.Core\.Validators\.
       type: Type

--- a/docs/sdks/managed.md
+++ b/docs/sdks/managed.md
@@ -42,13 +42,13 @@ builder.Services.AddSingleton<WidgetStore>();
 
 var app = builder.Build();
 
-app.UseBicepExtension();
+app.MapBicepExtension();
 app.MapGet("/about", () => "Widget extension");
 
 await app.RunAsync();
 ```
 
-`AddBicepExtension` creates one immutable handler registration and can only be called once. `UseBicepExtension` installs the shared middleware, maps the contract routes, and can also only be called once. The application fails startup if service registration succeeds but `UseBicepExtension` is omitted.
+`AddBicepExtension` creates one immutable handler registration and can only be called once. `MapBicepExtension` installs the shared middleware, maps the contract routes, and can also only be called once. The application fails startup if service registration succeeds but `MapBicepExtension` is omitted.
 
 ## Handler and behavior scopes
 
@@ -68,7 +68,7 @@ An unmatched value returns `UnsupportedExtensionVersion`. Missing resource handl
 
 ## Routes and health
 
-`UseBicepExtension()` maps the five bare contract routes:
+`MapBicepExtension()` maps the five bare contract routes:
 
 ```text
 POST /{extensionVersion}/resource/preview
@@ -85,7 +85,7 @@ It also maps `GET /ping`. Other methods receive `405 Method Not Allowed`.
 Map the interactive Scalar UI and OpenAPI document for local development:
 
 ```csharp
-app.MapDevelopmentApiExplorer(explorer => explorer
+app.MapManagedScalarApiExplorer(explorer => explorer
   .WithTitle("Widget Extension API")
   .ConfigureExamples(WidgetExamples.Configure));
 ```

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -76,7 +76,7 @@ builder.Services.AddBicepExtension(extension => extension
 
 var app = builder.Build();
 
-app.UseBicepExtension();
+app.MapBicepExtension();
 
 await app.RunAsync();
 ```
@@ -87,7 +87,7 @@ Key concepts:
 - **`AddBicepExtension`**: creates one immutable handler registration.
 - **`ForResourceType`**: scopes handlers to a specific resource type name.
 - **`AddHandler<T>`**: registers a handler. The SDK infers the operation (create, get, delete, preview, LRO) from the interface the handler implements.
-- **`UseBicepExtension`**: installs middleware and maps the five contract routes plus `GET /ping`.
+- **`MapBicepExtension`**: installs middleware and maps the five contract routes plus `GET /ping`.
 
 Handlers registered directly on the extension builder (outside `ForResourceType`) act as defaults. This is required for resource-type-agnostic operations such as LRO polling.
 

--- a/docs/tutorials/typed-handlers.md
+++ b/docs/tutorials/typed-handlers.md
@@ -182,7 +182,7 @@ builder.Services.AddBicepExtension(extension => extension
             .AddHandler<WidgetDeleteHandler>()));
 
 var app = builder.Build();
-app.UseBicepExtension();
+app.MapBicepExtension();
 
 await app.RunAsync();
 ```

--- a/sample/MagicEightBallExtension/Program.cs
+++ b/sample/MagicEightBallExtension/Program.cs
@@ -32,8 +32,8 @@ builder.Services.AddBicepExtension(extension => extension
 
 var app = builder.Build();
 
-app.UseBicepExtension();
-app.MapDevelopmentApiExplorer(explorer => explorer
+app.MapBicepExtension();
+app.MapManagedScalarApiExplorer(explorer => explorer
     .WithTitle("Magic Eight Ball Extension API")
     .ConfigureExamples(FortuneExamples.Configure));
 

--- a/sample/MagicEightBallExtension/README.md
+++ b/sample/MagicEightBallExtension/README.md
@@ -212,8 +212,8 @@ builder.Services.AddBicepExtension(extension => extension
 
 var app = builder.Build();
 
-app.UseBicepExtension();
-app.MapDevelopmentApiExplorer(explorer => explorer
+app.MapBicepExtension();
+app.MapManagedScalarApiExplorer(explorer => explorer
     .WithTitle("Magic Eight Ball Extension API")
     .ConfigureExamples(FortuneExamples.Configure));
 

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/ScalarExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/ScalarExtensions.cs
@@ -30,6 +30,15 @@ public static class BicepExtensionApiExplorer
     /// Maps the API explorer UI and the OpenAPI specification endpoint.
     /// Only registers routes when the application is running in the Development environment.
     /// </summary>
+    public static WebApplication MapBicepScalarApiExplorer(
+        this WebApplication app,
+        Action<ScalarApiExplorerBuilder>? configure = null) =>
+        MapDevelopment(app, configure);
+
+    /// <summary>
+    /// Maps the API explorer UI and the OpenAPI specification endpoint.
+    /// Only registers routes when the application is running in the Development environment.
+    /// </summary>
     public static WebApplication MapDevelopment(
         WebApplication app,
         Action<ScalarApiExplorerBuilder>? configure = null)

--- a/src/Azure.Deployments.Extensibility.Hosting.Managed.Tests.Unit/ManagedExtensionApplicationTests.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting.Managed.Tests.Unit/ManagedExtensionApplicationTests.cs
@@ -27,32 +27,32 @@ public class ManagedExtensionApplicationTests
     private static readonly BicepExtensionDescriptor Descriptor = new("Widget", "1.0.0");
 
     [Fact]
-    public void UseBicepExtension_WithoutServiceRegistration_Throws()
+    public void MapBicepExtension_WithoutServiceRegistration_Throws()
     {
         var builder = WebApplication.CreateBuilder();
         using var app = builder.Build();
 
-        var action = () => app.UseBicepExtension();
+        var action = () => app.MapBicepExtension();
 
         action.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
-    public void UseBicepExtension_CalledTwice_Throws()
+    public void MapBicepExtension_CalledTwice_Throws()
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddBicepExtension(extension => extension.AddHandler<GetHandler>(), Descriptor);
         using var app = builder.Build();
-        app.UseBicepExtension();
+        app.MapBicepExtension();
 
-        var action = () => app.UseBicepExtension();
+        var action = () => app.MapBicepExtension();
 
         action.Should().Throw<InvalidOperationException>()
-            .WithMessage("UseBicepExtension can only be called once.");
+            .WithMessage("MapBicepExtension can only be called once.");
     }
 
     [Fact]
-    public async Task Application_WithoutUseBicepExtension_FailsStartup()
+    public async Task Application_WithoutMapBicepExtension_FailsStartup()
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -62,17 +62,17 @@ public class ManagedExtensionApplicationTests
         var action = () => app.StartAsync();
 
         await action.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("Call UseBicepExtension before starting the application.");
+            .WithMessage("Call MapBicepExtension before starting the application.");
     }
 
     [Fact]
-    public void UseBicepExtension_ValidRegistration_MapsBareContractRoutes()
+    public void MapBicepExtension_ValidRegistration_MapsBareContractRoutes()
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddBicepExtension(extension => extension.AddHandler<GetHandler>(), Descriptor);
         using var app = builder.Build();
 
-        app.UseBicepExtension();
+        app.MapBicepExtension();
 
         var routes = ((IEndpointRouteBuilder)app).DataSources
             .SelectMany(dataSource => dataSource.Endpoints)
@@ -102,15 +102,15 @@ public class ManagedExtensionApplicationTests
     }
 
     [Fact]
-    public async Task MapDevelopmentApiExplorer_ConfiguredVersion_UsesIdentityVersion()
+    public async Task MapManagedScalarApiExplorer_ConfiguredVersion_UsesIdentityVersion()
     {
         var builder = WebApplication.CreateBuilder();
         builder.Environment.EnvironmentName = Environments.Development;
         builder.WebHost.UseTestServer();
         builder.Services.AddBicepExtension(extension => extension.AddHandler<GetHandler>(), Descriptor);
         await using var app = builder.Build();
-        app.UseBicepExtension();
-        app.MapDevelopmentApiExplorer(explorer => explorer
+        app.MapBicepExtension();
+        app.MapManagedScalarApiExplorer(explorer => explorer
             .WithTitle("Widget Extension API")
             .WithExtensionVersions("9.9.9"));
         await app.StartAsync();
@@ -205,7 +205,7 @@ public class ManagedExtensionApplicationTests
             context.Response.Headers["x-user-middleware"] = "applied";
             await next(context);
         });
-        app.UseBicepExtension();
+        app.MapBicepExtension();
         app.MapGet("/about", (UserService service) => service.Value);
         await app.StartAsync();
 
@@ -223,7 +223,7 @@ public class ManagedExtensionApplicationTests
         builder.WebHost.UseTestServer();
         builder.Services.AddBicepExtension(configure, Descriptor);
         var app = builder.Build();
-        app.UseBicepExtension();
+        app.MapBicepExtension();
         await app.StartAsync();
 
         return app;

--- a/src/Azure.Deployments.Extensibility.Hosting.Managed/Extensions/BicepManagedApplicationExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting.Managed/Extensions/BicepManagedApplicationExtensions.cs
@@ -20,7 +20,7 @@ public static class BicepManagedApplicationExtensions
     /// <summary>
     /// Maps the API explorer and OpenAPI document in the Development environment.
     /// </summary>
-    public static WebApplication MapDevelopmentApiExplorer(
+    public static WebApplication MapManagedScalarApiExplorer(
         this WebApplication app,
         Action<ScalarApiExplorerBuilder>? configure = null)
     {
@@ -28,8 +28,7 @@ public static class BicepManagedApplicationExtensions
 
         var state = app.Services.GetRequiredService<ManagedExtensionState>();
 
-        return BicepExtensionApiExplorer.MapDevelopment(
-            app,
+        return app.MapBicepScalarApiExplorer(
             builder =>
             {
                 configure?.Invoke(builder);
@@ -38,9 +37,17 @@ public static class BicepManagedApplicationExtensions
     }
 
     /// <summary>
+    /// Maps the API explorer and OpenAPI document in the Development environment.
+    /// </summary>
+    public static WebApplication MapDevelopmentApiExplorer(
+        this WebApplication app,
+        Action<ScalarApiExplorerBuilder>? configure = null) =>
+        app.MapManagedScalarApiExplorer(configure);
+
+    /// <summary>
     /// Installs the Bicep extension middleware and maps the contract and health endpoints.
     /// </summary>
-    public static WebApplication UseBicepExtension(this WebApplication app)
+    public static WebApplication MapBicepExtension(this WebApplication app)
     {
         ArgumentNullException.ThrowIfNull(app);
 
@@ -54,4 +61,10 @@ public static class BicepManagedApplicationExtensions
 
         return app;
     }
+
+    /// <summary>
+    /// Installs the Bicep extension middleware and maps the contract and health endpoints.
+    /// </summary>
+    public static WebApplication UseBicepExtension(this WebApplication app) =>
+        app.MapBicepExtension();
 }

--- a/src/Azure.Deployments.Extensibility.Hosting.Managed/README.md
+++ b/src/Azure.Deployments.Extensibility.Hosting.Managed/README.md
@@ -23,7 +23,7 @@ builder.Services.AddBicepExtension(extension => extension
         .AddHandler<WidgetGetHandler>()));
 
 var app = builder.Build();
-app.UseBicepExtension();
-app.MapDevelopmentApiExplorer();
+app.MapBicepExtension();
+app.MapManagedScalarApiExplorer();
 await app.RunAsync();
 ```

--- a/src/Azure.Deployments.Extensibility.Hosting.Managed/Validation/ManagedExtensionStartupValidator.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting.Managed/Validation/ManagedExtensionStartupValidator.cs
@@ -19,7 +19,7 @@ internal sealed class ManagedExtensionStartupValidator : IHostedService
         if (!this.state.ApplicationConfigured)
         {
             throw new InvalidOperationException(
-                "Call UseBicepExtension before starting the application.");
+                "Call MapBicepExtension before starting the application.");
         }
 
         return Task.CompletedTask;

--- a/src/Azure.Deployments.Extensibility.Hosting.Managed/Validation/ManagedExtensionState.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting.Managed/Validation/ManagedExtensionState.cs
@@ -22,7 +22,7 @@ internal sealed class ManagedExtensionState
         if (Interlocked.Exchange(ref this.applicationConfigured, 1) == 1)
         {
             throw new InvalidOperationException(
-                "UseBicepExtension can only be called once.");
+                "MapBicepExtension can only be called once.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add shorter preferred managed host APIs: `MapBicepExtension()` and `MapManagedScalarApiExplorer(...)`
- add the shared base Scalar mapper `MapBicepScalarApiExplorer(...)` while keeping existing aliases for compatibility
- update Managed SDK docs, tutorials, package README, and the Magic 8 Ball sample to use the preferred API names
- replace remaining arrow diagrams and long dashes from authored docs so the docs match the requested style

## Validation
- `dotnet test src/Azure.Deployments.Extensibility.Hosting.Managed.Tests.Unit/Azure.Deployments.Extensibility.Hosting.Managed.Tests.Unit.csproj`
- `dotnet build sample/MagicEightBallExtension/MagicEightBallExtension.csproj`
- parsed `docs/filterConfig.yml` and `docs/docfx.json`
- `git diff --check`
