### PR TITLE
Add Hosting SDK and docs updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ AutoTest.Net/
 
 # DocProject is a documentation generator add-in
 DocProject/buildhelp/
+docs/api-managed/
 DocProject/Help/*.HxT
 DocProject/Help/*.HxC
 DocProject/Help/*.hhc
@@ -354,7 +355,6 @@ docs/_site/
 docs/api/
 docs/sdks/api-core/
 docs/sdks/api-aspnetcore/
-docs/sdks/api-managed/
 
 # osx turds
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![codecov](https://codecov.io/gh/Azure/bicep-extensibility/branch/main/graph/badge.svg)](https://codecov.io/gh/Azure/bicep-extensibility)
 
-The repository contains source code for Bicep extensibility core package and first party providers owned by the Bicep team, including:
+The repository contains source code for the Bicep extensibility core package, the shared ASP.NET Core runtime, and the public Hosting SDK, including:
 - [Azure.Deployments.Extensibility.Core](src/Azure.Deployments.Extensibility.Core/)
+- [Azure.Deployments.Extensibility.AspNetCore](src/Azure.Deployments.Extensibility.AspNetCore/)
+- [Azure.Deployments.Extensibility.Hosting](src/Azure.Deployments.Extensibility.Hosting/)
 - [Azure.Deployments.Extensibility.Providers.Kubernetes](src/Azure.Deployments.Extensibility.Providers.Kubernetes/)
 
 ## Contributing

--- a/docs/filterConfig.yml
+++ b/docs/filterConfig.yml
@@ -1,12 +1,4 @@
 apiRules:
-  # Public Managed service extensions intentionally follow the Microsoft DI namespace convention
-  - include:
-      uidRegex: ^Microsoft\.Extensions\.DependencyInjection$
-      type: Namespace
-  - include:
-      uidRegex: ^Microsoft\.Extensions\.DependencyInjection\.BicepManagedServiceCollectionExtensions$
-      type: Type
-
   # Exclude BCL and framework namespaces — only Extensibility types should appear
   - exclude:
       uidRegex: ^System\.
@@ -20,13 +12,13 @@ apiRules:
 
   # Hide obsolete members and InternalsVisibleTo attributes
   - exclude:
+      type: Member
       hasAttribute:
         uid: System.ObsoleteAttribute
-      type: Member
   - exclude:
+      type: Member
       hasAttribute:
         uid: System.Runtime.CompilerServices.InternalsVisibleToAttribute
-      type: Member
 
   # Legacy V1 provider types — superseded by V2 contract
   - exclude:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,54 +2,55 @@
 
 [![codecov](https://codecov.io/gh/Azure/bicep-extensibility/branch/main/graph/badge.svg)](https://codecov.io/gh/Azure/bicep-extensibility)
 
-> [!WARNING]
-> The Bicep Extensibility platform is a work in progress. The SDKs are not yet ready for extension authors to consume. APIs and packages may change without notice, and there is no supported path to publish an extension yet. This documentation is published early for design review and feedback.
+The Bicep Extensibility platform lets you build **Bicep extensions**: HTTP services that connect Bicep deployments to custom resources.
 
-The Bicep Extensibility platform lets you build **Bicep extensions**: API services that let users deploy Azure data-plane or non-Azure resources through Bicep files and ARM templates.
+> [!WARNING]
+> The platform is still a work in progress. The SDKs and docs are changing quickly, and the public authoring experience is not ready for broad extension-author use yet.
 
 ## How it works
 
-A Bicep extension implements a set of resource operations (preview, create/update, get, delete) behind an HTTP API that conforms to the [Extension API Contract](contract/contract.md). The Bicep Extensibility Host, a component of `Microsoft.Resources/deployments`, routes deployment requests to your extension and manages the lifecycle.
-
-## Choose your path
-
-**New to Bicep extensions?**
-Start with [Getting Started](tutorials/getting-started.md), then work through the guides below.
-
-**Building a third-party or local extension?**
-
-1. [Getting Started](tutorials/getting-started.md)
-2. [Typed Handlers](tutorials/typed-handlers.md)
-3. [Behaviors](tutorials/behaviors.md)
-4. [Validators](tutorials/validators.md)
-5. [Managed SDK](sdks/managed.md)
-
-Keep the [Core SDK](sdks/core.md) and [API Contract](contract/contract.md) handy as reference.
-
-**On a first-party team?**
-First-party hosting (`Hosting.FirstParty`) is a self-hosted route for extensions that are closely integrated into the ARM deployment service, such as the MS Graph extension, and don't need the managed extension runtime. Teams on this route run their own extension service, so it's only for teams that want that model. Internal teams that don't need it can build on the [Managed SDK](sdks/managed.md) like anyone else. First-party hosting and its authoring guide are maintained internally; on this site, read the [API Contract](contract/contract.md) and [Core SDK](sdks/core.md), which apply to all extensions.
-
-**Integrating the wire protocol?**
-Read the [API Contract](contract/contract.md), then [Preview Operation](contract/preview-operation.md) and [Async Operations](contract/async-operations.md).
+A Bicep extension implements the resource operations your service needs: preview, create or update, get, delete. It exposes those operations through an HTTP API that follows the [Extension API Contract](contract/contract.md). The Bicep Extensibility Host, part of `Microsoft.Resources/deployments`, routes deployment requests to your extension and manages the lifecycle.
 
 ## SDKs
 
 | Package | Audience | Description |
 |---------|----------|-------------|
 | **Azure.Deployments.Extensibility.Core** | All extensions | Transport-agnostic models, handler interfaces, discriminated unions, structured errors, and a fluent validation framework. |
-| **Azure.Deployments.Extensibility.Hosting.Managed** | 3P, local, and internal | Public managed host that adds project identity, exact-version dispatch, lifecycle validation, and health checks. |
-| **Azure.Deployments.Extensibility.Hosting.FirstParty** | Self-hosted 1P | First-party host for extensions deeply integrated with the ARM deployment service that run their own service without the managed runtime. Maintained and documented internally. |
+| **Azure.Deployments.Extensibility.Hosting** | Third-party and local extensions | Public Hosting SDK for standard-host extensions with an exact-version resolver, health checks, and `/ping`. |
+| **Azure.Deployments.Extensibility.Hosting.FirstParty** | Microsoft-internal extensions | First-party hosting wrapper for teams that self-host their extension service and need the ARM-integrated hosting experience. |
+| **Azure.Deployments.Extensibility.Hosting.Managed** | Microsoft-internal extensions | Managed-runtime hosting option for teams that want the shared managed environment rather than self-hosting their extension service. |
+
+## Start here
+
+### Third-party extension authors
+If you are building a public or local extension, start here:
+
+1. [Getting Started](tutorials/getting-started.md) for a first walkthrough.
+2. [Hosting SDK](sdks/hosting.md) for the public host entry points.
+3. [Core SDK](sdks/core.md) for the shared contract models, handlers, and validation building blocks.
+4. [API Contract](contract/contract.md) as the reference for request and response behavior.
+
+### Microsoft-internal teams
+If you are working on an internal implementation, start here:
+
+1. [Core SDK](sdks/core.md) for the shared contract and validation layer.
+2. [AspNetCore runtime reference](sdks/aspnetcore.md) for the shared hosting and runtime implementation.
+3. [Hosting SDK](sdks/hosting.md) for context on the public authoring model and shared host behavior.
+4. Choose the hosting package that fits your runtime model:
+   - `Azure.Deployments.Extensibility.Hosting.FirstParty` for teams like Microsoft Graph that are deeply integrated with ARM and self-host their extension service.
+   - `Azure.Deployments.Extensibility.Hosting.Managed` for teams that want the managed runtime instead of self-hosting.
 
 > [!NOTE]
-> The Managed package includes its ASP.NET Core runtime dependency transitively. Extension authors should not reference the base runtime package directly.
+> For public and local authors, the Hosting SDK is the main entry point. For Microsoft-internal work, the shared runtime and the appropriate hosting wrapper package are the primary references.
 
-## Reference
+## Quick links
 
-- [API Contract](contract/contract.md): full specification of the extension protocol
-- [Preview Operation](contract/preview-operation.md): unevaluated expressions, preview metadata, What-If
-- [Async Operations](contract/async-operations.md): long-running operation patterns (RELO and LRO)
-- [Core SDK](sdks/core.md): models, `OneOf`, validation framework
-- [Managed SDK](sdks/managed.md): public hosting SDK for 3P, local, and internal extensions
-- <xref:Azure.Deployments.Extensibility.Core.V2.Contracts.Models>: Core API Reference
-- <xref:Azure.Deployments.Extensibility.Hosting.Managed>: Managed API Reference
-- [Sample Extension](https://github.com/Azure/bicep-extensibility/tree/main/sample/MagicEightBallExtension): Magic 8-Ball demo covering all 5 endpoints
+- [Getting Started](tutorials/getting-started.md) for a simple first walkthrough
+- [API Contract](contract/contract.md) for the full extension protocol
+- [Async Operations](contract/async-operations.md) for long-running operation patterns
+- [Preview Operation](contract/preview-operation.md) for preview and What-If behavior
+- [Core SDK](sdks/core.md) for the shared models and validation framework
+- [Hosting SDK](sdks/hosting.md) for the public host entry points
+- <xref:Azure.Deployments.Extensibility.Core.V2.Contracts.Models> for the Core API reference
+- <xref:Azure.Deployments.Extensibility.AspNetCore> for the AspNetCore API reference
+- [Sample Extension](https://github.com/Azure/bicep-extensibility/tree/main/sample/MagicEightBallExtension) for the Magic 8-Ball demo

--- a/docs/sdks/aspnetcore.md
+++ b/docs/sdks/aspnetcore.md
@@ -1,0 +1,26 @@
+# AspNetCore runtime reference
+
+> [!NOTE]
+> This page is a technical reference for the shared AspNetCore runtime implementation. It is not a public authoring guide for extension authors. Extension authors should use the [Hosting SDK](hosting.md) instead.
+
+The AspNetCore runtime provides the shared hosting layer for Bicep extensions. It handles JSON serialization, correlation headers, culture propagation, endpoint routing, and the behavior pipeline automatically.
+
+> [!WARNING]
+> The extensibility platform is still a work in progress. The shared runtime and SDKs are evolving quickly and are not yet ready for broad extension-author consumption.
+
+## Who should read this?
+
+Read this page if you are maintaining or extending the shared hosting/runtime implementation, or if you are part of a Microsoft-internal (1P) team that needs to understand the underlying infrastructure the SDKs build on.
+
+This is not the primary entry point for public extension authors. Third-party authors should start with the [Hosting SDK](hosting.md) and [Getting Started](../tutorials/getting-started.md).
+
+## What it provides
+
+- Middleware and request correlation/culture handling
+- Shared endpoint mapping for extension contract routes
+- Shared handler invocation and behavior pipeline support
+- Typed handler base classes and related runtime helpers
+
+## Relationship to the public SDK
+
+The public Hosting SDK wraps this runtime and exposes the standard-host entry points that extension authors should use.

--- a/docs/sdks/hosting.md
+++ b/docs/sdks/hosting.md
@@ -1,0 +1,68 @@
+# Hosting SDK
+
+The Hosting SDK is the public-facing wrapper for third-party and local Bicep extension authors. It builds on the shared AspNetCore runtime and provides a standard-host experience with one exact extension version, health checks, and a fixed `/ping` endpoint.
+
+> [!WARNING]
+> This SDK is still a work in progress. The public authoring experience is not yet ready for broad extension-author consumption.
+
+## Package
+
+- Package: `Azure.Deployments.Extensibility.Hosting`
+- Audience: third-party and local extension authors
+- Base dependency: `Azure.Deployments.Extensibility.AspNetCore`
+
+## Who should read this?
+
+Read this page if you are building a public or local Bicep extension and want the standard-host entry points for registering handlers and wiring the extension into ASP.NET Core.
+
+If you are on a Microsoft-internal (1P) team, this page is still useful as background on the public authoring model. Teams that self-host their extension service should use `Azure.Deployments.Extensibility.Hosting.FirstParty`, while teams that want the managed runtime should use `Azure.Deployments.Extensibility.Hosting.Managed`. Your primary implementation reference should be the shared [AspNetCore runtime reference](aspnetcore.md) plus the relevant internal wrapper docs when they are available.
+
+## Configure the host
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Azure.Deployments.Extensibility.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.AddBicepExtension("1.0.0", extension => extension
+    .ForResourceType("MyResource", resourceType => resourceType
+        .AddHandler<MyCreateOrUpdateHandler>()
+        .AddHandler<MyGetHandler>()
+        .AddHandler<MyDeleteHandler>()
+        .AddHandler<MyPreviewHandler>()));
+
+var app = builder.Build();
+app.UseBicepExtension();
+await app.RunAsync();
+```
+
+## Assembly metadata
+
+The Hosting SDK reads the extension identity from the entry assembly's `BicepExtensionIdentity` assembly metadata. Add the following to your extension project:
+
+```xml
+<ItemGroup>
+  <AssemblyMetadata Include="BicepExtensionIdentity" Value="MyExtension" />
+</ItemGroup>
+```
+
+## Development API explorer
+
+You can also enable the development-time Scalar API explorer for local authoring and testing:
+
+```csharp
+var app = builder.Build();
+app.UseBicepExtension();
+app.EnableDevelopmentScalarApiExplorer(explorer => explorer
+    .WithTitle("My Extension API")
+    .ConfigureExamples(examples => examples
+        .ForPreview(new { type = "MyResource" }, new { type = "MyResource" })));
+await app.RunAsync();
+```
+
+The explorer is only served when the app is running in the Development environment.
+
+## Notes
+
+- The Hosting SDK uses one exact extension version and compares route versions ordinally.
+- The aggregate host wires shared middleware, the bare contract endpoints, `/healthz`, and `/ping` for you.

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -1,18 +1,41 @@
-# SDK Reference
+# SDKs
 
-The Bicep Extensibility SDK is layered so hosting policy stays separate from the shared protocol runtime.
+The Bicep Extensibility platform ships a public Hosting SDK for third-party authors, plus first-party and managed wrappers for internal scenarios. Together they provide everything needed to build, host, and validate a Bicep extension.
+
+> [!WARNING]
+> The SDKs and docs are still evolving. The public authoring experience is a work in progress and is not yet ready for broad extension-author consumption.
 
 | Package | Description |
 |---------|-------------|
 | **Azure.Deployments.Extensibility.Core** | Transport-agnostic models, handler interfaces, discriminated unions (`OneOf`), structured errors, and a fluent validation framework. |
-| **Azure.Deployments.Extensibility.Hosting.Managed** | Public managed host with assembly identity, exact-version routing, startup validation, and `GET /ping`. Default route for 3P, local, and internal extensions. |
-| **Azure.Deployments.Extensibility.Hosting.FirstParty** | Self-hosted first-party host for extensions deeply integrated with the ARM deployment service, with multi-version routing and tenant policy integration. |
+| **Azure.Deployments.Extensibility.Hosting** | Public Hosting SDK for third-party and local extension authors that uses a standard host, an exact-version resolver, health checks, and `/ping`. |
+| **Azure.Deployments.Extensibility.Hosting.FirstParty** | First-party hosting wrapper for Microsoft-internal teams that self-host their extension service and need the ARM-integrated hosting experience. |
+| **Azure.Deployments.Extensibility.Hosting.Managed** | Managed-runtime hosting option for Microsoft-internal teams that want the shared managed environment rather than self-hosting their extension service. |
 
-Extension authors should reference **Hosting.Managed**. It brings in Core and the internal ASP.NET Core runtime transitively while preserving direct access to standard `WebApplicationBuilder` and `WebApplication` APIs. Do not reference the base runtime package directly.
+## Choose your entry point
 
-First-party hosting is a self-hosted route for a small set of extensions closely integrated with the ARM deployment service, such as the MS Graph extension. Its authoring documentation is maintained internally. Internal teams that don't need it can use Hosting.Managed like anyone else.
+### Third-party (3P) extension authors
+Read the public authoring path first:
+
+- [Hosting SDK](hosting.md) — the public package and host entry points.
+- [Core SDK](core.md) — the shared contract models, handlers, and validation primitives.
+- [Getting Started](../tutorials/getting-started.md) — a hands-on walkthrough for building your first extension.
+
+### Microsoft-internal (1P) teams
+Read the shared implementation path first:
+
+- [Core SDK](core.md) — the shared foundation used by both packaging models.
+- [AspNetCore runtime reference](aspnetcore.md) — the underlying hosting/runtime layer.
+- [Hosting SDK](hosting.md) — useful context for the public authoring model and shared host behavior.
+- Choose the hosting package that fits your runtime model:
+  - `Azure.Deployments.Extensibility.Hosting.FirstParty` for teams like Microsoft Graph that are deeply integrated with ARM and self-host their extension service.
+  - `Azure.Deployments.Extensibility.Hosting.Managed` for teams that want the managed runtime instead of self-hosting.
+
+The **Core** package is used by both 1P and 3P extensions.
 
 ## Next steps
 
-- [Core SDK](core.md): models, `OneOf`, validation
-- [Managed SDK](managed.md): build a 3P or local extension
+- [Core SDK](core.md) — models, `OneOf`, validation
+- [Hosting SDK](hosting.md) — public wrapper for standard-host extensions
+
+For implementation details of the shared AspNetCore runtime, see [AspNetCore runtime reference](aspnetcore.md).

--- a/docs/sdks/toc.yml
+++ b/docs/sdks/toc.yml
@@ -5,8 +5,5 @@
   items:
   - name: API Reference
     href: api-core/
-- name: Managed
-  href: managed.md
-  items:
-  - name: API Reference
-    href: api-managed/
+- name: Hosting
+  href: hosting.md

--- a/docs/tutorials/behaviors.md
+++ b/docs/tutorials/behaviors.md
@@ -4,17 +4,18 @@ Behaviors are pipeline decorators that wrap handler invocations. Use them for cr
 
 ## How behaviors work
 
-A behavior receives the request and a `next` delegate. Call `next` to continue the pipeline, or return early to short-circuit. A request flows through each registered behavior in order before reaching the handler, and the response flows back out in reverse:
+A behavior receives the request and a `next` delegate. Call `next` to continue the pipeline, or return early to short-circuit:
 
 ```
-Request
-   [Behavior A]   can inspect, modify, or short-circuit
-   [Behavior B]   can inspect, modify, or short-circuit
-   [Handler]      does the work
-Response
+Request → [Behavior A] → [Behavior B] → [Handler] → Response
+                ↑              ↑              ↑
+            can inspect    can inspect    does the work
+            can modify     can modify
+            can short-     can short-
+            circuit        circuit
 ```
 
-Behaviors execute in registration order: global first, then registration-scoped, then resource-type-scoped.
+Behaviors execute in registration order: **global → extension-scoped → resource-type-scoped**.
 
 ## Operation-specific interfaces
 
@@ -120,19 +121,17 @@ public sealed partial class ResponseLoggingBehavior :
 Run for **every handler** across all extension versions:
 
 ```csharp
-builder.Services.AddBicepExtension(extension => extension
-    .AddGlobalHandlerBehavior<ResponseLoggingBehavior>()
-    .AddHandler<OperationStatusHandler>());
+builder.Services.AddBicepExtensionGlobalHandlerBehavior<ResponseLoggingBehavior>();
 ```
 
-### Registration-scoped behaviors
+### Version-scoped behaviors
 
-Run after the Managed host resolves its exact extension version:
+Run for handlers in a specific version range:
 
 ```csharp
-builder.Services.AddBicepExtension(extension => extension
+builder.AddBicepExtension("1.0.0", extension => extension
     .AddHandlerBehavior(sp => new ApiVersionValidationBehavior("2024-01-01", "2024-01-01-preview"))
-    .AddHandler<OperationStatusHandler>());
+    ...);
 ```
 
 ### Resource-type-scoped behaviors
@@ -140,7 +139,7 @@ builder.Services.AddBicepExtension(extension => extension
 Run only for handlers of a specific resource type:
 
 ```csharp
-.ForResourceType("Widget", type => type
+.ForResourceType("Widget", resourceType => resourceType
     .AddHandlerBehavior<WidgetAuthorizationBehavior>()
     .AddHandler<WidgetCreateOrUpdateHandler>()
     ...);
@@ -165,21 +164,22 @@ Or use the generic overload when all dependencies are in DI:
 Given this registration:
 
 ```csharp
-builder.Services.AddBicepExtension(extension => extension
-    .AddGlobalHandlerBehavior<LoggingBehavior>()
+builder.Services.AddBicepExtensionGlobalHandlerBehavior<LoggingBehavior>();
+
+builder.AddBicepExtension("1.0.0", extension => extension
     .AddHandlerBehavior<ApiVersionBehavior>()
-    .ForResourceType("Widget", type => type
+    .ForResourceType("Widget", resourceType => resourceType
         .AddHandlerBehavior<WidgetAuthBehavior>()
         .AddHandler<WidgetCreateOrUpdateHandler>()));
 ```
 
-A create-or-update request for version `1.0.0` and type `Widget` executes in this order:
+A create-or-update request for version `1.0.0` and type `Widget` executes:
 
 ```
-LoggingBehavior, then ApiVersionBehavior, then WidgetAuthBehavior, then WidgetCreateOrUpdateHandler
+LoggingBehavior → ApiVersionBehavior → WidgetAuthBehavior → WidgetCreateOrUpdateHandler
 ```
 
 ## Next steps
 
-- [Typed Handlers](typed-handlers.md): use strongly-typed models in your handlers.
-- [Validators](validators.md): validate request models with a fluent DSL.
+- [Typed Handlers](typed-handlers.md) — use strongly-typed models in your handlers.
+- [Validators](validators.md) — validate request models with a fluent DSL.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,29 +1,23 @@
 # Getting Started
 
-> [!WARNING]
-> The Bicep Extensibility platform is a work in progress and the SDKs are not yet ready for extension authors to consume. Follow this guide to explore and give feedback, not to build a production extension.
+> [!NOTE]
+> These tutorials use the public **Hosting SDK** wrapper for third-party and local extension authors. See [Hosting SDK](../sdks/hosting.md) for the public entry point.
 
-This guide walks you through building a third-party or local Bicep extension using the Managed SDK.
+This guide walks you through building your first Bicep extension using the public Hosting SDK.
+
+> [!WARNING]
+> The extensibility platform is still a work in progress. The public authoring experience is not yet ready for broad extension-author consumption.
 
 ## Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 
 ## 1. Create a new project
 
 ```bash
 dotnet new web -n MyExtension
 cd MyExtension
-dotnet add package Azure.Deployments.Extensibility.Hosting.Managed
-```
-
-Declare one extension name and exact version in the project file:
-
-```xml
-<PropertyGroup>
-    <BicepExtensionName>MyExtension</BicepExtensionName>
-    <BicepExtensionVersion>1.0.0</BicepExtensionVersion>
-</PropertyGroup>
+dotnet add package Azure.Deployments.Extensibility.Hosting
 ```
 
 ## 2. Define a handler
@@ -63,33 +57,31 @@ public class MyResourceCreateOrUpdateHandler : IResourceCreateOrUpdateHandler
 Replace the contents of `Program.cs`:
 
 ```csharp
-using Azure.Deployments.Extensibility.Hosting.Managed.Extensions;
+using Azure.Deployments.Extensibility.AspNetCore;
+using Microsoft.AspNetCore.Builder;
 
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddBicepExtension(extension => extension
-    .ForResourceType("MyResource", type => type
-    .AddHandler<MyResourceCreateOrUpdateHandler>()
-    .AddHandler<MyResourceGetHandler>()
-    .AddHandler<MyResourceDeleteHandler>()
-    .AddHandler<MyResourcePreviewHandler>()));
+builder.AddBicepExtension("1.0.0", extension => extension
+    .ForResourceType("MyResource", resourceType => resourceType
+        .AddHandler<MyResourceCreateOrUpdateHandler>()
+        .AddHandler<MyResourceGetHandler>()
+        .AddHandler<MyResourceDeleteHandler>()
+        .AddHandler<MyResourcePreviewHandler>()));
 
 var app = builder.Build();
-
 app.UseBicepExtension();
-
 await app.RunAsync();
 ```
 
+The Hosting SDK also expects the entry assembly to declare `BicepExtensionIdentity` assembly metadata so it can identify the extension.
+
 Key concepts:
 
-- **`BicepExtensionVersion`**: declares the one exact version hosted by this process.
-- **`AddBicepExtension`**: creates one immutable handler registration.
-- **`ForResourceType`**: scopes handlers to a specific resource type name.
-- **`AddHandler<T>`**: registers a handler. The SDK infers the operation (create, get, delete, preview, LRO) from the interface the handler implements.
-- **`UseBicepExtension`**: installs middleware and maps the five contract routes plus `GET /ping`.
+- **`AddBicepExtension`** — registers a single exact extension version and the host wiring for the extension.
+- **`ForResourceType`** — scopes handlers to a specific resource type name.
+- **`AddHandler<T>`** — registers a handler. The SDK infers the operation (create, get, delete, preview, LRO) from the interface the handler implements.
 
-Handlers registered directly on the extension builder (outside `ForResourceType`) act as defaults. This is required for resource-type-agnostic operations such as LRO polling.
+Handlers registered directly on the extension builder (outside `ForResourceType`) act as **generic handlers** that match any resource type without a type-specific handler. This is useful for resource-type-agnostic operations like LRO polling.
 
 ## 4. Run and test
 
@@ -121,22 +113,21 @@ curl -X POST http://localhost:5000/1.0.0/resource/preview \
 Behaviors are pipeline decorators that run before and after handlers. Use them for cross-cutting concerns like validation, logging, or retry logic.
 
 ```csharp
-builder.Services.AddBicepExtension(extension => extension
-    .AddGlobalHandlerBehavior<LoggingBehavior>()
+builder.AddBicepExtension("1.0.0", extension => extension
     .AddHandlerBehavior<MyValidationBehavior>()
-    .ForResourceType("MyResource", type => type
+    .ForResourceType("MyResource", resourceType => resourceType
         .AddHandler<MyResourceCreateOrUpdateHandler>()));
 ```
 
 Behaviors can be registered at three levels:
-- **Global**: `extension.AddGlobalHandlerBehavior<T>()` also wraps unsupported extension versions.
-- **Registration-scoped**: `extension.AddHandlerBehavior<T>()` runs after the exact version resolves.
-- **Resource-type-scoped**: `type.AddHandlerBehavior<T>()` runs only for handlers of that resource type.
+- **Global** — `builder.Services.AddBicepExtensionGlobalHandlerBehavior<T>()` runs for every handler across all versions.
+- **Extension-scoped** — `extension.AddHandlerBehavior<T>()` runs for handlers in the extension registration.
+- **Resource-type-scoped** — `resourceType.AddHandlerBehavior<T>()` runs only for handlers of that resource type.
 
 ## Next Steps
 
-- [Typed Handlers](typed-handlers.md): use strongly-typed models instead of raw `JsonObject`.
-- [Behaviors](behaviors.md): add cross-cutting concerns like validation and logging.
-- [Validators](validators.md): validate requests with a fluent DSL.
+- [Typed Handlers](typed-handlers.md) — use strongly-typed models instead of raw `JsonObject`.
+- [Behaviors](behaviors.md) — add cross-cutting concerns like validation and logging.
+- [Validators](validators.md) — validate requests with a fluent DSL.
 - Read the [API Contract](../contract/contract.md) for the complete protocol specification.
 - Explore the [Magic 8-Ball sample](https://github.com/Azure/bicep-extensibility/tree/main/sample/MagicEightBallExtension) for a full working example covering all 5 endpoints.

--- a/docs/tutorials/typed-handlers.md
+++ b/docs/tutorials/typed-handlers.md
@@ -170,20 +170,19 @@ public class WidgetPreviewHandler
 ## 3. Register the handlers
 
 ```csharp
-using Azure.Deployments.Extensibility.Hosting.Managed.Extensions;
+using Azure.Deployments.Extensibility.AspNetCore;
+using Microsoft.AspNetCore.Builder;
 
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddBicepExtension(extension => extension
-    .ForResourceType("Widget", type => type
-            .AddHandler<WidgetPreviewHandler>()
-            .AddHandler<WidgetCreateOrUpdateHandler>()
-            .AddHandler<WidgetGetHandler>()
-            .AddHandler<WidgetDeleteHandler>()));
+builder.AddBicepExtension("1.0.0", extension => extension
+    .ForResourceType("Widget", resourceType => resourceType
+        .AddHandler<WidgetPreviewHandler>()
+        .AddHandler<WidgetCreateOrUpdateHandler>()
+        .AddHandler<WidgetGetHandler>()
+        .AddHandler<WidgetDeleteHandler>()));
 
 var app = builder.Build();
 app.UseBicepExtension();
-
 await app.RunAsync();
 ```
 
@@ -211,12 +210,12 @@ The base class exposes conversion methods for when you need to cross between typ
 
 | Method | Direction |
 |--------|-----------|
-| `ToResource(TypedResource)` | Typed to untyped |
-| `ToTypedResource(Resource)` | Untyped to typed |
-| `ToNullableResource(TypedResource?)` | Typed to untyped (nullable) |
-| `ToResourceSpecification(TypedResourceSpecification)` | Typed to untyped |
+| `ToResource(TypedResource)` | Typed → Untyped |
+| `ToTypedResource(Resource)` | Untyped → Typed |
+| `ToNullableResource(TypedResource?)` | Typed → Untyped (nullable) |
+| `ToResourceSpecification(TypedResourceSpecification)` | Typed → Untyped |
 
 ## Next steps
 
-- [Behaviors](behaviors.md): add cross-cutting validation or logging around your handlers.
-- [Validators](validators.md): validate request models with a fluent DSL.
+- [Behaviors](behaviors.md) — add cross-cutting validation or logging around your handlers.
+- [Validators](validators.md) — validate request models with a fluent DSL.

--- a/sample/MagicEightBallExtension/Program.cs
+++ b/sample/MagicEightBallExtension/Program.cs
@@ -3,26 +3,48 @@
 
 using Azure.Deployments.Extensibility.AspNetCore;
 using Azure.Deployments.Extensibility.AspNetCore.Behaviors;
-using Azure.Deployments.Extensibility.Hosting.Managed.Extensions;
 using MagicEightBallExtension;
 using MagicEightBallExtension.Behaviors;
 using MagicEightBallExtension.Data;
 using MagicEightBallExtension.Handlers;
 using Microsoft.AspNetCore.Http.Json;
+using V1 = MagicEightBallExtension.Handlers.V1;
 
-var builder = WebApplication.CreateBuilder(args);
+var app = ExtensionApplication.Create(args);
 
-builder.Services.AddSingleton<FortuneStore>();
-builder.Services.Configure<JsonOptions>(options =>
+// Register application services.
+app.ConfigureServices(services =>
 {
-    options.SerializerOptions.TypeInfoResolverChain.Insert(0, FortuneModelSerializerContext.Default);
+    services.AddSingleton<FortuneStore>();
+
+    // Demonstrate adding a custom serializer context to the JSON options.
+    services.Configure<JsonOptions>(options =>
+    {
+        options.SerializerOptions.TypeInfoResolverChain.Insert(0, FortuneModelSerializerContext.Default);
+    });
 });
 
-builder.Services.AddBicepExtension(extension => extension
-    .AddGlobalHandlerBehavior<ResponseLoggingBehavior>()
-    .AddGlobalHandlerBehavior<NameValidationBehavior>()
-    .AddGlobalHandlerBehavior(_ => new PreviewRewriteBehavior(new FakeValueSubstitutionPreviewRewriter()))
-    .AddHandlerBehavior(_ => new ApiVersionValidationBehavior("2025-01-01", "2025-01-01-preview"))
+// Global behaviors — run for every handler invocation.
+app.AddGlobalHandlerBehavior<ResponseLoggingBehavior>();
+app.AddGlobalHandlerBehavior<NameValidationBehavior>();
+app.AddGlobalHandlerBehavior(_ => new PreviewRewriteBehavior(new FakeValueSubstitutionPreviewRewriter()));
+
+// v1 handlers
+app.AddExtensionVersion("1.*.*", version => version
+    // Version-scoped behavior — validates that the resource API version is 2024-01-01 or 2024-01-01-preview.
+    .AddHandlerBehavior(sp => new ApiVersionValidationBehavior("2024-01-01", "2024-01-01-preview"))
+    // Generic (default) handler — not scoped to a resource type.
+    .AddHandler<FortuneLongRunningOperationGetHandler>()
+    // Resource-type-specific handlers for "Fortune".
+    .ForResourceType("Fortune", type => type
+        .AddHandler<V1.FortunePreviewHandler>()
+        .AddHandler<V1.FortuneCreateOrUpdateHandler>()
+        .AddHandler<V1.FortuneGetHandler>()
+        .AddHandler<V1.FortuneDeleteHandler>()));
+
+// v2 handlers
+app.AddExtensionVersion("2.*.*", version => version
+    .AddHandlerBehavior(sp => new ApiVersionValidationBehavior("2025-01-01", "2025-01-01-preview")) // 2025-01-01 or 2025-01-01-preview
     .AddHandler<FortuneLongRunningOperationGetHandler>()
     .ForResourceType("Fortune", type => type
         .AddHandler<FortunePreviewHandler>()
@@ -30,11 +52,9 @@ builder.Services.AddBicepExtension(extension => extension
         .AddHandler<FortuneGetHandler>()
         .AddHandler<FortuneDeleteHandler>()));
 
-var app = builder.Build();
-
-app.UseBicepExtension();
-app.MapDevelopmentApiExplorer(explorer => explorer
+app.EnableDevelopmentScalarApiExplorer(explorer => explorer
     .WithTitle("Magic Eight Ball Extension API")
+    .WithExtensionVersions("1.0.0", "2.0.0")
     .ConfigureExamples(FortuneExamples.Configure));
 
 await app.RunAsync();

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/ExtensionVersionBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/ExtensionVersionBuilder.cs
@@ -16,6 +16,11 @@ namespace Azure.Deployments.Extensibility.AspNetCore;
 /// Handlers registered directly on this builder are default (generic) handlers.
 /// Use <see cref="ForResourceType"/> to register handlers scoped to a named resource type.
 /// </summary>
+/// <remarks>
+/// This legacy hosting surface is kept for compatibility with existing consumers.
+/// New applications should use the Azure.Deployments.Extensibility.Hosting package instead.
+/// This type is slated for removal in a future release.
+/// </remarks>
 public sealed class ExtensionVersionBuilder
 {
     private readonly IServiceCollection services;

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepExtensionBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepExtensionBuilder.cs
@@ -9,6 +9,11 @@ namespace Azure.Deployments.Extensibility.AspNetCore;
 /// <summary>
 /// Configures a version-independent set of Bicep extension handlers and behaviors.
 /// </summary>
+/// <remarks>
+/// This legacy hosting surface is kept for compatibility with existing consumers.
+/// New applications should use the Azure.Deployments.Extensibility.Hosting package instead.
+/// This interface is slated for removal in a future release.
+/// </remarks>
 public interface IBicepExtensionBuilder
 {
     /// <summary>

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepResourceTypeBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/IBicepResourceTypeBuilder.cs
@@ -9,6 +9,11 @@ namespace Azure.Deployments.Extensibility.AspNetCore;
 /// <summary>
 /// Configures handlers and behaviors for one Bicep resource type.
 /// </summary>
+/// <remarks>
+/// This legacy hosting surface is kept for compatibility with existing consumers.
+/// New applications should use the Azure.Deployments.Extensibility.Hosting package instead.
+/// This interface is slated for removal in a future release.
+/// </remarks>
 public interface IBicepResourceTypeBuilder
 {
     /// <summary>

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/ResourceTypeBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/ResourceTypeBuilder.cs
@@ -15,6 +15,11 @@ namespace Azure.Deployments.Extensibility.AspNetCore;
 /// Configures handler registrations scoped to a specific resource type
 /// within an extension version range.
 /// </summary>
+/// <remarks>
+/// This legacy hosting surface is kept for compatibility with existing consumers.
+/// New applications should use the Azure.Deployments.Extensibility.Hosting package instead.
+/// This type is slated for removal in a future release.
+/// </remarks>
 public sealed class ResourceTypeBuilder
 {
     private readonly IServiceCollection services;

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Builders/ScalarApiExplorerBuilder.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Builders/ScalarApiExplorerBuilder.cs
@@ -11,11 +11,11 @@ namespace Azure.Deployments.Extensibility.AspNetCore.Builders;
 /// </summary>
 public class ScalarApiExplorerBuilder
 {
-    internal string Title { get; private set; } = BicepExtensionApiExplorer.DefaultTitle;
+    public string Title { get; private set; } = BicepScalarApiExplorerExtensions.DefaultTitle;
 
-    internal string[]? ExtensionVersions { get; private set; }
+    public string[]? ExtensionVersions { get; private set; }
 
-    internal Action<OpenApiExamplesBuilder>? ExamplesConfigurator { get; private set; }
+    public Action<OpenApiExamplesBuilder>? ExamplesConfigurator { get; private set; }
 
     /// <summary>
     /// Sets the title displayed in the Scalar API explorer UI.

--- a/src/Azure.Deployments.Extensibility.AspNetCore/ExtensionApplication.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/ExtensionApplication.cs
@@ -19,6 +19,11 @@ namespace Azure.Deployments.Extensibility.AspNetCore;
 /// Provides a fluent API that handles JSON serialization, middleware, routing,
 /// and pipeline behavior configuration automatically.
 /// </summary>
+/// <remarks>
+/// This legacy hosting surface is kept for compatibility with existing consumers.
+/// New applications should use the Azure.Deployments.Extensibility.Hosting package instead.
+/// This type is slated for removal in a future release.
+/// </remarks>
 /// <example>
 /// <code><![CDATA[
 /// ExtensionApplication.Create(args)
@@ -29,7 +34,6 @@ namespace Azure.Deployments.Extensibility.AspNetCore;
 ///     .Run();
 /// ]]></code>
 /// </example>
-// TODO: Remove this legacy hosting surface after existing consumers migrate to Hosting.FirstParty.
 public class ExtensionApplication
 {
     private readonly HandlerRegistry handlerRegistry = new();
@@ -199,7 +203,10 @@ public class ExtensionApplication
     {
         if (this.apiExplorerBuilder is { } explorer)
         {
-            BicepExtensionApiExplorer.MapDevelopment(app, explorer);
+            app.MapBicepScalarApiExplorer(
+                explorer.ExamplesConfigurator,
+                explorer.Title,
+                explorer.ExtensionVersions);
         }
 
         app.MapResourceActions();

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/ScalarExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/ScalarExtensions.cs
@@ -18,33 +18,37 @@ using System.Text.Json.Nodes;
 namespace Azure.Deployments.Extensibility.AspNetCore.Extensions;
 
 /// <summary>
-/// Maps the shared, development-time API explorer UI and OpenAPI document.
+/// Extension methods for adding the Scalar API explorer to a Bicep extension host.
 /// </summary>
-public static class BicepExtensionApiExplorer
+public static class BicepScalarApiExplorerExtensions
 {
     private const string OpenApiDocumentName = "v2";
     private const string DefaultServerUrl = "http://localhost:8080";
     internal const string DefaultTitle = "Bicep Extensibility Provider API";
 
     /// <summary>
-    /// Maps the API explorer UI and the OpenAPI specification endpoint.
+    /// Maps the Scalar API explorer UI and the OpenAPI specification endpoint.
     /// Only registers routes when the application is running in the Development environment.
     /// </summary>
-    public static WebApplication MapDevelopment(
-        WebApplication app,
-        Action<ScalarApiExplorerBuilder>? configure = null)
-    {
-        ArgumentNullException.ThrowIfNull(app);
-
-        var builder = new ScalarApiExplorerBuilder();
-        configure?.Invoke(builder);
-
-        return MapDevelopment(app, builder);
-    }
-
-    internal static WebApplication MapDevelopment(
-        WebApplication app,
-        ScalarApiExplorerBuilder builder)
+    /// <example>
+    /// <code>
+    /// var app = builder.Build();
+    /// app.UseDevelopmentApiExplorer(examples =>
+    /// {
+    ///     examples.ForCreateOrUpdate(
+    ///         request: new { type = "MyResource", properties = new { name = "example" } },
+    ///         response: new { type = "MyResource", identifiers = new { name = "example" }, properties = new { name = "example" } });
+    /// });
+    /// app.MapResourceActions();
+    /// app.MapLongRunningOperationActions();
+    /// app.Run();
+    /// </code>
+    /// </example>
+    public static WebApplication MapBicepScalarApiExplorer(
+        this WebApplication app,
+        Action<OpenApiExamplesBuilder>? configureExamples = null,
+        string title = DefaultTitle,
+        string[]? extensionVersions = null)
     {
         if (!app.Environment.IsDevelopment())
         {
@@ -52,11 +56,7 @@ public static class BicepExtensionApiExplorer
         }
 
         var serializerOptions = app.Services.GetRequiredService<IOptions<JsonOptions>>().Value.SerializerOptions;
-        var openApiJson = BuildOpenApiDocument(
-            builder.ExamplesConfigurator,
-            builder.ExtensionVersions,
-            builder.Title,
-            serializerOptions);
+        var openApiJson = BuildOpenApiDocument(configureExamples, extensionVersions, title, serializerOptions);
 
         app.MapGet($"/openapi/{OpenApiDocumentName}.json", (HttpRequest request) =>
         {
@@ -69,7 +69,7 @@ public static class BicepExtensionApiExplorer
         app.MapScalarApiReference(options =>
         {
             options
-                .WithTitle(builder.Title)
+                .WithTitle(title)
                 .WithOpenApiRoutePattern($"/openapi/{OpenApiDocumentName}.json");
         });
 
@@ -78,7 +78,7 @@ public static class BicepExtensionApiExplorer
 
     private static string BuildOpenApiDocument(Action<OpenApiExamplesBuilder>? configureExamples, string[]? extensionVersions, string title, JsonSerializerOptions serializerOptions)
     {
-        var assembly = typeof(BicepExtensionApiExplorer).Assembly;
+        var assembly = typeof(BicepScalarApiExplorerExtensions).Assembly;
         using var stream = assembly.GetManifestResourceStream("openapi.yaml")
             ?? throw new InvalidOperationException("Embedded OpenAPI specification not found.");
 

--- a/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/WebApplicationScalarApiExplorerExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.AspNetCore/Extensions/WebApplicationScalarApiExplorerExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore.Builders;
+using Azure.Deployments.Extensibility.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Extension methods for enabling the development-time Scalar API explorer on a standard ASP.NET Core app.
+/// </summary>
+public static class WebApplicationScalarApiExplorerExtensions
+{
+    /// <summary>
+    /// Enables the development-time Scalar API explorer with optional configuration.
+    /// </summary>
+    public static WebApplication EnableDevelopmentScalarApiExplorer(
+        this WebApplication app,
+        Action<ScalarApiExplorerBuilder>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var builder = new ScalarApiExplorerBuilder();
+        configure?.Invoke(builder);
+
+        app.MapBicepScalarApiExplorer(
+            builder.ExamplesConfigurator,
+            builder.Title,
+            builder.ExtensionVersions);
+
+        return app;
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Hosting.Tests.Unit/Azure.Deployments.Extensibility.Hosting.Tests.Unit.csproj
+++ b/src/Azure.Deployments.Extensibility.Hosting.Tests.Unit/Azure.Deployments.Extensibility.Hosting.Tests.Unit.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.29" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Deployments.Extensibility.Hosting\Azure.Deployments.Extensibility.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="BicepExtensionIdentity" Value="HostingSdkTests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Azure.Deployments.Extensibility.Hosting.Tests.Unit/ManagedBicepExtensionTests.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting.Tests.Unit/ManagedBicepExtensionTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Handlers;
+using Azure.Deployments.Extensibility.Core.V2.Contracts.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Azure.Deployments.Extensibility.Hosting.Tests.Unit;
+
+public class ManagedBicepExtensionTests
+{
+    [Fact]
+    public async Task AddBicepExtension_MapsEndpoints()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.AddBicepExtension("1.0.0", extension => extension.AddHandler<EndpointGetHandler>());
+
+        await using var app = builder.Build();
+        app.UseBicepExtension();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Add("x-ms-client-request-id", "00000000-0000-0000-0000-000000000001");
+        client.DefaultRequestHeaders.Add("x-ms-correlation-request-id", "00000000-0000-0000-0000-000000000002");
+
+        var response = await client.PostAsJsonAsync(
+            "/1.0.0/resource/get",
+            new ResourceReference
+            {
+                Type = "Widget",
+                Identifiers = new JsonObject { ["name"] = "example" },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resource = await response.Content.ReadFromJsonAsync<Resource>();
+        resource.Should().NotBeNull();
+        resource!.Type.Should().Be("Widget");
+    }
+
+    [Fact]
+    public async Task EnableDevelopmentScalarApiExplorer_MapsOpenApiEndpoint()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Environment.EnvironmentName = Environments.Development;
+        builder.AddBicepExtension("1.0.0", extension => extension.AddHandler<EndpointGetHandler>());
+
+        await using var app = builder.Build();
+        app.UseBicepExtension();
+        app.EnableDevelopmentScalarApiExplorer(explorer => explorer.WithTitle("My Extension API"));
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/openapi/v2.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("My Extension API");
+    }
+
+    [Fact]
+    public void UseBicepExtension_Twice_Throws()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.AddBicepExtension("1.0.0", extension => extension.AddHandler<EndpointGetHandler>());
+
+        using var app = builder.Build();
+        app.UseBicepExtension();
+
+        var action = () => app.UseBicepExtension();
+
+        action.Should().Throw<InvalidOperationException>().WithMessage("*already been configured*");
+    }
+
+    private sealed class EndpointGetHandler : IResourceGetHandler
+    {
+        public Task<OneOf<Resource?, ErrorResponse>> HandleAsync(
+            ResourceReference request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<OneOf<Resource?, ErrorResponse>>(new Resource
+            {
+                Type = request.Type,
+                Identifiers = request.Identifiers,
+                Properties = new JsonObject { ["name"] = "example" },
+            });
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Hosting/Azure.Deployments.Extensibility.Hosting.csproj
+++ b/src/Azure.Deployments.Extensibility.Hosting/Azure.Deployments.Extensibility.Hosting.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <EnableNuget>true</EnableNuget>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>ASP.NET Core hosting SDK for Bicep extensions. Provides a standard-host wrapper around the shared AspNetCore runtime with an exact-version resolver, health checks, and /ping support.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Deployments.Extensibility.AspNetCore\Azure.Deployments.Extensibility.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Deployments.Extensibility.Hosting.Tests.Unit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Azure.Deployments.Extensibility.Hosting/ExactVersionBicepExtensionResolver.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting/ExactVersionBicepExtensionResolver.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore;
+
+namespace Azure.Deployments.Extensibility.Hosting;
+
+/// <summary>
+/// Resolves a single exact extension version without parsing route versions as semantic ranges.
+/// </summary>
+public sealed class ExactVersionBicepExtensionResolver : IBicepExtensionResolver
+{
+    private readonly string configuredVersion;
+    private readonly BicepExtensionRegistration registration;
+
+    public ExactVersionBicepExtensionResolver(string configuredVersion, BicepExtensionRegistration registration)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuredVersion);
+        ArgumentNullException.ThrowIfNull(registration);
+
+        this.configuredVersion = configuredVersion;
+        this.registration = registration;
+    }
+
+    public BicepExtensionRegistration? Resolve(string extensionVersion)
+    {
+        if (string.IsNullOrWhiteSpace(extensionVersion))
+        {
+            return null;
+        }
+
+        return string.Equals(extensionVersion, this.configuredVersion, StringComparison.Ordinal)
+            ? this.registration
+            : null;
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Hosting/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Configures the Hosting SDK Bicep extension host on a standard ASP.NET Core builder.
+/// </summary>
+public static class WebApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Registers a single immutable extension registration and the exact-version resolver for it.
+    /// </summary>
+    public static WebApplicationBuilder AddBicepExtension(
+        this WebApplicationBuilder builder,
+        string extensionVersion,
+        Action<IBicepExtensionBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionVersion);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        builder.Services.AddBicepExtensionServices();
+        builder.Services.AddHealthChecks();
+
+        var registration = BicepExtensionRegistration.Create(builder.Services, configure);
+        builder.Services.AddSingleton<IBicepExtensionResolver>(new ExactVersionBicepExtensionResolver(extensionVersion, registration));
+        builder.Services.AddSingleton(new Azure.Deployments.Extensibility.Hosting.HostingBicepExtensionConfiguration(
+            extensionVersion,
+            GetExtensionIdentity()));
+
+        return builder;
+    }
+
+    private static string GetExtensionIdentity()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+        var metadata = assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => string.Equals(attribute.Key, "BicepExtensionIdentity", StringComparison.OrdinalIgnoreCase));
+
+        if (string.IsNullOrWhiteSpace(metadata?.Value))
+        {
+            throw new InvalidOperationException(
+                "The Hosting SDK requires assembly metadata named 'BicepExtensionIdentity'. Add <AssemblyMetadata Include=\"BicepExtensionIdentity\" Value=\"...\" /> to your project file.");
+        }
+
+        return metadata.Value;
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Hosting/Extensions/WebApplicationExtensions.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.AspNetCore;
+using Azure.Deployments.Extensibility.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Wires the shared Bicep extension middleware, endpoints, health checks, and /ping route onto a real app.
+/// </summary>
+public static class WebApplicationExtensions
+{
+    /// <summary>
+    /// Configures the Hosting SDK middleware and routes.
+    /// </summary>
+    public static WebApplication UseBicepExtension(this WebApplication app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var resolvers = app.Services.GetServices<IBicepExtensionResolver>().ToArray();
+        if (resolvers.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"The Hosting SDK expects exactly one '{nameof(IBicepExtensionResolver)}' registration, but found {resolvers.Length}.");
+        }
+
+        var configuration = app.Services.GetService<Azure.Deployments.Extensibility.Hosting.HostingBicepExtensionConfiguration>();
+        if (configuration is null)
+        {
+            throw new InvalidOperationException(
+                "The Hosting SDK must be configured with AddBicepExtension before calling UseBicepExtension.");
+        }
+
+        if (configuration.AggregationConfigured)
+        {
+            throw new InvalidOperationException("The Hosting SDK has already been configured.");
+        }
+
+        configuration.AggregationConfigured = true;
+        app.UseBicepExtensionMiddlewares();
+        app.MapBicepExtensionEndpoints();
+        app.MapGet("/ping", () => Results.Text("pong"));
+        app.MapHealthChecks("/healthz");
+
+        return app;
+    }
+}

--- a/src/Azure.Deployments.Extensibility.Hosting/HostingBicepExtensionConfiguration.cs
+++ b/src/Azure.Deployments.Extensibility.Hosting/HostingBicepExtensionConfiguration.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Deployments.Extensibility.Hosting;
+
+internal sealed class HostingBicepExtensionConfiguration
+{
+    public HostingBicepExtensionConfiguration(string extensionVersion, string extensionIdentity)
+    {
+        this.ExtensionVersion = extensionVersion;
+        this.ExtensionIdentity = extensionIdentity;
+    }
+
+    public string ExtensionVersion { get; }
+
+    public string ExtensionIdentity { get; }
+
+    public bool AggregationConfigured { get; set; }
+}

--- a/src/Azure.Deployments.Extensibility.Hosting/README.md
+++ b/src/Azure.Deployments.Extensibility.Hosting/README.md
@@ -1,0 +1,32 @@
+# Azure.Deployments.Extensibility.Hosting
+
+The Hosting SDK provides a public, standard-host wrapper around the shared Bicep extensibility ASP.NET Core runtime for third-party and local extension authors.
+
+## Quick start
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Azure.Deployments.Extensibility.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.AddBicepExtension("1.0.0", extension => extension
+    .ForResourceType("MyResource", resourceType => resourceType
+        .AddHandler<MyCreateOrUpdateHandler>()
+        .AddHandler<MyGetHandler>()
+        .AddHandler<MyDeleteHandler>()
+        .AddHandler<MyPreviewHandler>()));
+
+var app = builder.Build();
+app.UseBicepExtension();
+await app.RunAsync();
+```
+
+## Assembly metadata
+
+The Hosting SDK reads the extension identity from the entry assembly's `BicepExtensionIdentity` assembly metadata. Add the following to your extension project:
+
+```xml
+<ItemGroup>
+  <AssemblyMetadata Include="BicepExtensionIdentity" Value="MyExtension" />
+</ItemGroup>
+```


### PR DESCRIPTION
## Summary

- add a public Hosting SDK wrapper with standard-host registration, exact-version resolution, health endpoints, and extension identity handling
- preserve AspNetCore compatibility while restoring Scalar API explorer support for standard-host apps
- update the docs and sample to reflect the new 3P/1P packaging model and work-in-progress guidance
- add unit coverage for the Hosting SDK behavior

## Notes

- The docs now distinguish between `Azure.Deployments.Extensibility.Hosting.FirstParty` for self-hosted 1P scenarios and `Azure.Deployments.Extensibility.Hosting.Managed` for managed-runtime scenarios.
- The DocFX filter config was updated to the syntax supported by DocFX.
