### PR TITLE
[Draft] docs: add learning path structure and concept intro

### DIFF
--- a/docs/contract/index.md
+++ b/docs/contract/index.md
@@ -1,6 +1,22 @@
-# Contract
+# How Extensions Work
 
-The Bicep Extension API Contract defines the protocol between the Bicep Extensibility Host (a component of `Microsoft.Resources/deployments`) and your extension. All extensions must conform to this contract.
+A Bicep extension is an HTTP API service that sits between Azure and the resources your users want to deploy: Azure data-plane resources, or resources outside Azure entirely. When a user deploys a Bicep file that references your resource types, the **Bicep Extensibility Host** (a component of `Microsoft.Resources/deployments`) routes the deployment operations to your extension and manages its lifecycle.
+
+```
+Bicep file > deployments RP > Extensibility Host > your extension > resource provider
+```
+
+Your extension implements up to five operations defined by the Extension API Contract:
+
+| Operation | Purpose |
+|-----------|---------|
+| **Preview** | Simulates a create or update without persisting changes. Powers preflight validation and What-If. |
+| **Create or Update** | Creates or updates a resource, synchronously or via a long-running operation. |
+| **Get** | Retrieves the current state of a resource. |
+| **Delete** | Deletes a resource, synchronously or via a long-running operation. |
+| **Get Long-Running Operation** | Polls the status of an in-flight operation. |
+
+Each request carries an **extension version** in its route (`/{extensionVersion}/resource/...`) and a **resource API version** in its body. A managed extension hosts exactly one extension version per process; the resource API version is validated by your own handlers.
 
 ## Documents
 
@@ -9,3 +25,7 @@ The Bicep Extension API Contract defines the protocol between the Bicep Extensib
 | [API Contract](contract.md) | The complete V2 contract: operations, models, HTTP binding, authentication, and limits. |
 | [Preview Operation](preview-operation.md) | Deep-dive on the preview operation: unevaluated expressions, preview metadata, What-If integration. |
 | [Async Operations](async-operations.md) | Long-running operation patterns: RELO (recommended) and LRO, with sequence diagrams and examples. |
+
+## Next step
+
+- [Getting started](../tutorials/getting-started.md): build and run your first extension.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,12 @@ Start with [Getting Started](tutorials/getting-started.md), then work through th
 
 **Building a third-party or local extension?**
 
-1. [Getting Started](tutorials/getting-started.md)
-2. [Typed Handlers](tutorials/typed-handlers.md)
-3. [Behaviors](tutorials/behaviors.md)
-4. [Validators](tutorials/validators.md)
-5. [Managed SDK](sdks/managed.md)
+1. [How extensions work](contract/index.md)
+2. [Getting Started](tutorials/getting-started.md)
+3. [Typed Handlers](tutorials/typed-handlers.md)
+4. [Behaviors](tutorials/behaviors.md)
+5. [Validators](tutorials/validators.md)
+6. [Managed SDK](sdks/managed.md)
 
 Keep the [Core SDK](sdks/core.md) and [API Contract](contract/contract.md) handy as reference.
 

--- a/docs/tutorials/behaviors.md
+++ b/docs/tutorials/behaviors.md
@@ -1,5 +1,7 @@
 # Behaviors
 
+*Learning path, step 4 of 5. Previous: [Typed handlers](typed-handlers.md)*
+
 Behaviors are pipeline decorators that wrap handler invocations. Use them for cross-cutting concerns like validation, logging, authorization, or error handling.
 
 ## How behaviors work

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+*Learning path, step 2 of 5. Previous: [How extensions work](../contract/index.md)*
+
 > [!WARNING]
 > The Bicep Extensibility platform is a work in progress and the SDKs are not yet ready for extension authors to consume. Follow this guide to explore and give feedback, not to build a production extension.
 

--- a/docs/tutorials/toc.yml
+++ b/docs/tutorials/toc.yml
@@ -1,6 +1,13 @@
-- name: Typed Handlers
-  href: typed-handlers.md
-- name: Behaviors
-  href: behaviors.md
-- name: Validators
-  href: validators.md
+- name: Learning Path
+  href: getting-started.md
+  items:
+  - name: 1. How extensions work
+    href: ../contract/index.md
+  - name: 2. Getting started
+    href: getting-started.md
+  - name: 3. Typed handlers
+    href: typed-handlers.md
+  - name: 4. Behaviors
+    href: behaviors.md
+  - name: 5. Validators
+    href: validators.md

--- a/docs/tutorials/typed-handlers.md
+++ b/docs/tutorials/typed-handlers.md
@@ -1,5 +1,7 @@
 # Typed Handlers
 
+*Learning path, step 3 of 5. Previous: [Getting started](getting-started.md)*
+
 This tutorial shows how to use the typed handler base classes to work with strongly-typed C# models instead of raw `JsonObject` in your handlers.
 
 ## Why typed handlers?

--- a/docs/tutorials/validators.md
+++ b/docs/tutorials/validators.md
@@ -1,5 +1,7 @@
 # Validators
 
+*Learning path, step 5 of 5. Previous: [Behaviors](behaviors.md)*
+
 The Core SDK includes a fluent validation framework built around `ModelValidator<T>`. Use it to validate request models (e.g., `ResourceSpecification`) with composable, declarative rules.
 
 ## Defining a validator


### PR DESCRIPTION
## Summary

Small docs-IA improvement on top of the current site structure:

- **`docs/contract/index.md`** becomes a "How extensions work" concept page: a short request-flow overview (`Bicep file > deployments RP > Extensibility Host > your extension`) and a table of the five contract operations, so new extension authors understand the protocol before hitting the dense API spec.
- **Numbered learning path** in `docs/tutorials/toc.yml`: 1. How extensions work → 2. Getting started → 3. Typed handlers → 4. Behaviors → 5. Validators, with matching step breadcrumbs ("Learning path, step N of 5. Previous: …") on each tutorial page.
- **Home page** gains the concept page as step 1 of the third-party/local extension path.

No content is removed; the contract document table is preserved on the concept page.

### Validation

- `docfx build` passes (only the pre-existing `api-managed` link warning, which resolves when `docfx metadata` runs first in CI).